### PR TITLE
[v3.2 Plugin Feature request] Compatibility with vue router children

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -165,7 +165,18 @@ export default {
 		},
 		currentPageCondition() {
 			const currentRoute = this.$route;
-			return Routes.some(route => route.path === currentRoute.path && route.condition);
+			let checkRoute = function(route, isChild) {
+				let flag = (route.path === currentRoute.path && route.condition);
+				if (!flag && isChild) {
+					let curPath = currentRoute.path.replace(/\/$/, '');
+					if (curPath.endsWith(route.path))
+						flag = (curPath.substring(0, curPath.length-route.path.length) + route.path === curPath && route.condition)
+				}
+				if (!flag && route.children != undefined)
+					flag = route.children.some(child => checkRoute(child, true));
+				return flag;
+			};
+			return Routes.some(route => checkRoute(route));
 		},
 		toggleGlobalContainerColor() {
 			if (this.hideGlobalContainer) {


### PR DESCRIPTION
Add compatibility for vue router children, specifically for plugins to register routes that all share a common base component but dont want every route to display in the side bar. If a plugin wants custom navigation, they can use this, otherwise, the default will also still work just fine.
This actually worked just fine to begin with, but the page condition validation wasn't capable of detecting child pages as valid. This will allow routes to be set like this:

            registerRoute(this, {
			Category: {
				Whatever: {
					icon: 'mdi-icon',
					caption: 'caption',
					path: '/path',
					children: [
						{
							path: '',
							component: CustomComponents.RootComponent
						},
						{
							path: 'childpath',  // resolves to /path/childpath
							component: CustomComponents.DifferentComponent,
							condition: true,
						}
					]
				}
			}
		});

That function runs in the plugins base component's install function, which has its own router-view component. Child routes render in the new router-view, and the base component acts like a wrapper, also allowing all child routes to use any style that is placed in the base wrapper. It could be a useful architecture for complex plugins, and I plan on using it if possible.