### PR TITLE
GCode Viewer Updates

### DIFF
--- a/src/plugins/GCodeViewer/GCodeViewer.vue
+++ b/src/plugins/GCodeViewer/GCodeViewer.vue
@@ -122,7 +122,7 @@
                         {{ $t('plugins.gcodeViewer.loadLocalGCode.caption')  }}
                     </v-btn>
                     <input ref="fileInput" type="file" :accept="'.g,.gcode,.gc,.gco,.nc,.ngc,.tap'" hidden @change="fileSelected" multiple />
-                    <v-switch class="mt-4" v-model="showObjectSelection" :disabled="!canCancelObject" :label="jobSelectionLabel" :title="$t('plugins.gcodeviewer.showObjectSelection.title')"></v-switch>
+                    <v-switch class="mt-4" v-model="showObjectSelection" :disabled="!canCancelObject" :label="jobSelectionLabel" :title="$t('plugins.gcodeViewer.showObjectSelection.title')"></v-switch>
                     <v-switch v-model="showCursor" :label="$t('plugins.gcodeViewer.showCursor')"></v-switch>
                     <v-switch v-model="showTravelLines" :label="$t('plugins.gcodeViewer.showTravels')"></v-switch>
                 </v-card>

--- a/src/plugins/GCodeViewer/GCodeViewer.vue
+++ b/src/plugins/GCodeViewer/GCodeViewer.vue
@@ -94,6 +94,8 @@
                 </v-btn>
                 <br />
                 <v-btn small class="toggle-menu-button-close mb-10" @click="drawer = !drawer" :title="$t('plugins.gcodeViewer.showConfiguration')"><v-icon>mdi-cog</v-icon></v-btn>
+				<br/>
+				<v-btn small class="toggle-menu-button-close mb-10" @click="loadRunningJob" v-show="!(!isJobRunning || loading || visualizingCurrentJob)" :title="$t('plugins.gcodeViewer.loadCurrentJob.title')"><v-icon>mdi-printer-3d</v-icon></v-btn>
                 <br />
                 <v-btn small class="toggle-menu-button-close" v-show="loading" @click="cancelLoad" :title="$t('plugins.gcodeViewer.cancelLoad')"><v-icon color="red">mdi-cancel</v-icon></v-btn>
             </div>

--- a/src/plugins/GCodeViewer/viewer/buildobjects.js
+++ b/src/plugins/GCodeViewer/viewer/buildobjects.js
@@ -177,23 +177,33 @@ export default class {
       return;
     }
 
+    let hitTestTimer  =0;
+    let mouseDown  = false;
+    let cancelHitTimer = 0;
+    
     this.observableControls = this.scene.onPointerObservable.add((pointerInfo) => {
+      
+      
       let pickInfo = pointerInfo.pickInfo;
       switch (pointerInfo.type) {
         case PointerEventTypes.POINTERDOWN:
           {
-            this.cancelHitTimer = Date.now();
+            mouseDown = true;
+            cancelHitTimer = Date.now();
           }
           break;
         case PointerEventTypes.POINTERUP:
           {
-            if (Date.now() - this.cancelHitTimer > 200) {
+            mouseDown = false;
+            if (Date.now() - cancelHitTimer > 200) {
               return;
             }
             this.handleClick(pickInfo);
           }
           break;
         case PointerEventTypes.POINTERMOVE: {
+          if(mouseDown || Date.now() - hitTestTimer < 100) return;
+          hitTestTimer = Date.now();
           this.handlePointerMove(pickInfo);
         }
       }

--- a/src/plugins/GCodeViewer/viewer/gcodeprocessor.js
+++ b/src/plugins/GCodeViewer/viewer/gcodeprocessor.js
@@ -595,11 +595,13 @@ export default class {
 
     lineMesh.isVisible = true;
     lineMesh.isPickable = false;
+    lineMesh.alwaysSelectAsActiveMesh = true;
+    lineMesh.material.alpha = 0.01;
     lineMesh.markVerticesDataAsUpdatable(VertexBuffer.ColorKind);
-    lineMesh.material.needDepthPrePass = true;
-    lineMesh.material.needAlphaTesting = () => true;
+    lineMesh.material.backFaceCulling = true;
+    lineMesh.material.transparencyMode = StandardMaterial.MATERIAL_ALPHATESTANDBLEND;
     lineMesh.material.useVertexAlpha = true;
-    lineMesh.material.transparencyMode = 3;
+    
 
     let lastRendered = 0;
 

--- a/src/plugins/GCodeViewer/viewer/gcodeprocessor.js
+++ b/src/plugins/GCodeViewer/viewer/gcodeprocessor.js
@@ -1,11 +1,9 @@
-/*eslint no-useless-escape: 0*/
 'use strict';
 
-import { Engine } from '@babylonjs/core/Engines/engine'
-import { Vector3  } from '@babylonjs/core/Maths/math.vector'
-import { Color4  } from '@babylonjs/core/Maths/math.color'
-import { VertexBuffer  } from '@babylonjs/core/Meshes/buffer'
-import { StandardMaterial  } from '@babylonjs/core/Materials/standardMaterial'
+import { Vector3 } from '@babylonjs/core/Maths/math.vector'
+import { Color4 } from '@babylonjs/core/Maths/math.color'
+import { VertexBuffer } from '@babylonjs/core/Meshes/buffer'
+import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial'
 import { SolidParticleSystem } from '@babylonjs/core/Particles/solidParticleSystem'
 import { PointsCloudSystem } from '@babylonjs/core/Particles/pointsCloudSystem'
 import { MeshBuilder } from '@babylonjs/core/Meshes/meshBuilder'
@@ -48,7 +46,7 @@ export default class {
     this.liveTracking = false; //Tracks if we loaded the current job to enable live rendering
     this.liveTrackingShowSolid = false; //Flag if we want to continue showing the whole model while rendering
 
-    this.materialTransparency = 0.5;
+    this.materialTransparency = 0.3;
     this.gcodeLineIndex = [];
     this.gcodeFilePosition = 0;
 
@@ -121,12 +119,7 @@ export default class {
     this.renderTravels = true;
     this.lineVertexAlpha = false;
 
-    this.forceWireMode = localStorage.getItem('forceWireMode');
-    if (!this.forceWireMode) {
-      this.forceWireMode = false;
-    } else {
-      JSON.parse(this.forceWireMode);
-    }
+    this.forceWireMode = localStorage.getItem('forceWireMode') === "true";
 
     this.spreadLines = false;
     this.spreadLineAmount = 10;
@@ -273,7 +266,7 @@ export default class {
     this.minFeedRate = Number.MAX_VALUE;
     this.maxFeedRate = 0;
     this.hasSpindle = false;
-    this.currentColor =  this.extruderColors[0].clone();
+    this.currentColor = this.extruderColors[0].clone();
   }
 
   async processGcodeFile(file, renderQuality, clearCache) {
@@ -456,29 +449,29 @@ export default class {
         case 'G2':
         case 'G3': {
           tokens = tokenString.split(/(?=[GXYZIJFR])/);
-          let cw = tokens.filter( t => t === "G2");
+          let cw = tokens.filter(t => t === "G2");
           let arcResult = doArc(tokens, this.currentPosition, !this.absolute, 1);
           let curPt = this.currentPosition.clone();
           arcResult.points.forEach((point, idx) => {
             let line = new gcodeLine();
             line.gcodeLineNumber = this.gcodeLineNumber;
             line.start = curPt.clone();
-            line.end = new Vector3(point.x, point.y,point.z);
+            line.end = new Vector3(point.x, point.y, point.z);
             line.color = this.currentColor.clone();
-            if(this.debug){
-              line.color = cw ? new Color4(0,1,1,1) :  new Color4(1,1,0,1)
-              if(idx == 0){
-              line.color = new Color4(0,1,0,1);
+            if (this.debug) {
+              line.color = cw ? new Color4(0, 1, 1, 1) : new Color4(1, 1, 0, 1)
+              if (idx == 0) {
+                line.color = new Color4(0, 1, 0, 1);
               }
             }
             curPt = line.end.clone();
             this.lines.push(line);
           });
-         //Last point to currentposition
+          //Last point to currentposition
 
-          
 
-          this.currentPosition = new Vector3( arcResult.position.x, arcResult.position.y, arcResult.position.z);
+
+          this.currentPosition = new Vector3(arcResult.position.x, arcResult.position.y, arcResult.position.z);
         } break;
         case 'G28':
           //Home
@@ -550,61 +543,6 @@ export default class {
     }
   }
 
-
-
-
-
-/*
-  processGCodeLine(line) {
-    var code = line.split(/(?=[XYZ])/);
-    switch (code[0]) {
-      case "G0":
-      case "G1":
-        for (let tokenIdx = 1; tokenIdx < code.length; tokenIdx++) {
-          var token = code[tokenIdx];
-          switch (token[0]) {
-            case "X": this.absolute ? this.currentPosition.x = Number(token.substring(1)) : this.currentPosition.x += Number(token.substring(1)); break;
-            case "Y": this.absolute ? this.currentPosition.y = Number(token.substring(1)) : this.currentPosition.y += Number(token.substring(1)); break;
-            case "Z": this.absolute ? this.currentPosition.z = Number(token.substring(1)) : this.currentPosition.z += Number(token.substring(1)); break;
-          }
-          console.log(this.currentPosition);
-        }
-        break;
-      default: break;
-    }
-  }
-
-  processMCodeLine(line, lineNumber) {
-    console.log(`${line} ${lineNumber}`)
-  }
-
-  async processLineV2(tokenString, lineNumber) {
-
-    //Remove the comments in the line
-    let commentIndex = tokenString.indexOf(';');
-    if (commentIndex > -1) {
-      tokenString = tokenString.substring(0, commentIndex - 1).trim();
-    }
-    tokenString = tokenString.toUpperCase()
-
-    switch (tokenString[0]) {
-      case "G":
-        this.processGCodeLine(tokenString, lineNumber);
-        break;
-      case "M":
-        break;
-      default:
-        break;
-    }
-
-
-
-  }
-*/
-
-
-
-
   renderLineMode(scene) {
     let that = this;
     let lastUpdate = Date.now();
@@ -619,24 +557,24 @@ export default class {
     if (this.debug) {
       console.log(this.lines[0]);
     }
+
+    let transparentValue = this.lineVertexAlpha ? this.materialTransparency : 1;
+
     for (var lineIdx = 0; lineIdx < this.lines.length; lineIdx++) {
       let line = this.lines[lineIdx];
       this.gcodeLineIndex[meshIndex].push(line.gcodeLineNumber);
       let data = line.getPoints(scene);
 
-      if (this.liveTrackingShowSolid) {
-        data.colors[0].a = this.lineVertexAlpha ? this.materialTransparency : 1;
-        data.colors[1].a = this.lineVertexAlpha ? this.materialTransparency : 1;
-      } else if (this.liveTracking) {
-        data.colors[0].a = 0;
-        data.colors[1].a = 0;
-      } else if (this.lineVertexAlpha) {
-        data.colors[0].a = this.materialTransparency;
-        data.colors[1].a = this.materialTransparency;
+
+      if (this.liveTracking) {
+
+        data.colors[0].a = this.liveTrackingShowSolid ? transparentValue : 0
+        data.colors[1].a = this.liveTrackingShowSolid ? transparentValue : 0;
       } else {
-        data.colors[0].a = 1;
-        data.colors[1].a = 1;
+        data.colors[0].a = transparentValue;
+        data.colors[1].a = transparentValue;
       }
+
       lineArray.push(data.points);
       colorArray.push(data.colors);
     }
@@ -647,7 +585,7 @@ export default class {
         lines: lineArray,
         colors: colorArray,
         updatable: true,
-        useVertexAlpha: this.lineVertexAlpha || this.liveTracking,
+        useVertexAlpha: true,
       },
       scene
     );
@@ -657,24 +595,17 @@ export default class {
 
     lineMesh.isVisible = true;
     lineMesh.isPickable = false;
-    lineMesh.alphaIndex = 0; // this.lineMeshIndex; //Testing
-    lineMesh.doNotSyncBoundingInfo = true;
-    lineMesh.freezeWorldMatrix(); // prevents from re-computing the World Matrix each frame
-    lineMesh.freezeNormals();
     lineMesh.markVerticesDataAsUpdatable(VertexBuffer.ColorKind);
-
-    const lineSolidMat = new StandardMaterial('solidMaterial', scene);
-    lineSolidMat.specularColor = this.specularColor;
-    lineSolidMat.diffuseColor = new Color4(1, 1, 1, 0.5);
-    lineSolidMat.alphaMode = Engine.ALPHA_ONEONE;
-    lineSolidMat.needAlphaTesting = () => true;
-    lineMesh.material = lineSolidMat;
+    lineMesh.material.needDepthPrePass = true;
+    lineMesh.material.needAlphaTesting = () => true;
+    lineMesh.material.useVertexAlpha = true;
+    lineMesh.material.transparencyMode = 3;
 
     let lastRendered = 0;
 
     let beforeRenderFunc = function () {
-      
-      if (!that.liveTracking && !runComplete && !(that.gcodeFilePosition  && lastRendered >= that.gcodeLineIndex[meshIndex].length - 1)) {
+
+      if (!that.liveTracking && !runComplete && !(that.gcodeFilePosition && lastRendered >= that.gcodeLineIndex[meshIndex].length - 1)) {
         return;
       } else if (Date.now() - lastUpdate < that.refreshTime) {
         return;
@@ -688,8 +619,6 @@ export default class {
           return;
         }
 
-      
-      
         let renderTo = -1;
         let renderAhead = -1;
         for (var renderToIdx = lastRendered; renderToIdx < that.gcodeLineIndex[meshIndex].length; renderToIdx++) {
@@ -760,7 +689,7 @@ export default class {
     let sps = new SolidParticleSystem('gcodemodel' + meshIndex, scene, {
       updatable: true,
       enableMultiMaterial: true,
-      useVertexAlpha: this.lineVertexAlpha || this.liveTracking,
+      useVertexAlpha: true
     });
 
     sps.addShape(box, this.lines.length, {
@@ -769,24 +698,26 @@ export default class {
 
     sps.buildMesh();
 
+
+    let transparentValue = this.lineVertexAlpha ? this.materialTransparency : 1;
+    if (this.liveTracking) {
+      transparentValue = this.liveTrackingShowSolid ? transparentValue : 0
+    }
+
     //Build out solid and transparent material.
     let solidMat = new StandardMaterial('solidMaterial', scene);
     solidMat.specularColor = this.specularColor;
     let transparentMat = new StandardMaterial('transparentMaterial', scene);
     transparentMat.specularColor = this.specularColor;
-    if (this.lineVertexAlpha || this.liveTracking) {
-      transparentMat.alpha = this.liveTracking && !this.liveTrackingShowSolid ? 0 : this.materialTransparency;
-      transparentMat.needAlphaTesting = () => true;
-      transparentMat.separateCullingPass = true;
-      transparentMat.backFaceCulling = true;
-    }
+    transparentMat.alpha = this.liveTrackingShowSolid ? this.materialTransparency :  transparentValue;
+    transparentMat.needAlphaTesting = () => true;
+    transparentMat.separateCullingPass = true;
+    transparentMat.backFaceCulling = true;
 
     sps.setMultiMaterial([solidMat, transparentMat]);
     sps.setParticles();
     sps.computeSubMeshes();
     sps.mesh.alphaIndex = 0; // this.lineMeshIndex; //meshIndex;
-    sps.mesh.freezeWorldMatrix(); // prevents from re-computing the World Matrix each frame
-    sps.mesh.freezeNormals();
     sps.mesh.isPickable = false;
     sps.mesh.doNotSyncBoundingInfo = true;
 
@@ -941,11 +872,3 @@ export default class {
     localStorage.setItem('forceWireMode', enabled);
   }
 }
-
-window.mobilecheck = function () {
-  var check = false;
-  (function (a) {
-    if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true;
-  })(navigator.userAgent || navigator.vendor || window.opera);
-  return check;
-};

--- a/src/plugins/GCodeViewer/viewer/gcodeviewer.js
+++ b/src/plugins/GCodeViewer/viewer/gcodeviewer.js
@@ -430,7 +430,6 @@ export default class {
   }
   updateCameraInertiaProperties() {
 
-    console.log()
     if (this.cameraInertia) {
       this.orbitCamera.speed = 2;
       this.orbitCamera.inertia = 0.9;


### PR DESCRIPTION
Added a load running job mini-button.

Change in object selection to reduce the amount of hit tests done when rotating the
scene. With a fair number of objects the scene would lag when rotating the view when objects were visible.

Force Line Rendering was not being read from localStorage properly.

Significant improvement to how Force Line Rendering, Transparency and Show Solid work. When tracking a live job the lines were transparent even if transparency was turned off.

Transparency is now better respected through the render modes.