### PR TITLE
Fix for G3 commands

### DIFF
--- a/src/plugins/GCodeViewer/viewer/gcodeprocessor.js
+++ b/src/plugins/GCodeViewer/viewer/gcodeprocessor.js
@@ -449,7 +449,7 @@ export default class {
           } break;
         case 'G2':
         case 'G3': {
-          tokens = tokenString.split(/(?=[GXYZIJFR])/);
+          tokens = tokenString.split(/(?=[GXYZIJFRE])/);
           let cw = tokens.filter(t => t === "G2");
           let arcResult = doArc(tokens, this.currentPosition, !this.absolute, 1);
           let curPt = this.currentPosition.clone();

--- a/src/plugins/GCodeViewer/viewer/utils.js
+++ b/src/plugins/GCodeViewer/viewer/utils.js
@@ -18,7 +18,7 @@ export function doArc(tokens, currentPosition, relativeMove, arcSegLength) {
         i = 0,
         j = 0,
         r = 0;
-    var cw = tokens.filter(t => t.startsWith('G2')) ? 1 : -1;  //use the sign to drive direction
+    var cw = tokens.some(t => t.includes('G2'));
     //read params
     for (let tokenIdx = 0; tokenIdx < tokens.length; tokenIdx++) {
         let token = tokens[tokenIdx];
@@ -98,13 +98,13 @@ export function doArc(tokens, currentPosition, relativeMove, arcSegLength) {
     }
 
     let arcAngleIncrement = totalArc / totalSegments;
-    arcAngleIncrement *= cw ? -1 :1;
+    arcAngleIncrement *= cw ? -1 : 1;
 
     let points = new Array();
 
     let zDist = currZ - z;
     let zStep = zDist / totalSegments;
-    
+
     //get points for the arc
     let px = currX;
     let py = currY;
@@ -113,8 +113,8 @@ export function doArc(tokens, currentPosition, relativeMove, arcSegLength) {
     let currentAngle = arcCurrentAngle;
     for (let moveIdx = 0; moveIdx < totalSegments - 1; moveIdx++) {
         currentAngle += arcAngleIncrement;
-        px = centerX + arcRadius * Math.cos(currentAngle) ;
-        py = centerY + arcRadius * Math.sin(currentAngle)  ;
+        px = centerX + arcRadius * Math.cos(currentAngle);
+        py = centerY + arcRadius * Math.sin(currentAngle);
         pz += zStep;
         points.push({ x: px, y: pz, z: py });
     }


### PR DESCRIPTION
There was an issue with G3 commands creating invalid arcs on the rendering. 
Reported by PCR on forum.

This fix addresses the G3 issue.

Before
![image](https://user-images.githubusercontent.com/12520045/103035108-28c7ea80-452c-11eb-82f4-ddcadbe99946.png)

After
![image](https://user-images.githubusercontent.com/12520045/103035111-2bc2db00-452c-11eb-9852-a51a32c765cc.png)

