### PR TITLE
Style changes for input switches and checkboxes.

### DIFF
--- a/src/plugins/GCodeViewer/GCodeViewer.vue
+++ b/src/plugins/GCodeViewer/GCodeViewer.vue
@@ -20,13 +20,14 @@
 
 .v-input--checkbox {
 	margin: 0;
-	padding: 0;
+	padding-left: 12px;
 }
 
 .v-input--switch {
 	margin: 0;
-	padding: 0;
+	padding-left: 12px;
 }
+
 .viewer-box {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Adjust the padding for the switches and checkboxes to avoid clipping the highlight. 