### PR TITLE
Configurable main menu

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -63,7 +63,7 @@ textarea {
 			</div>
 
 			<v-list class="pt-0" :expand="$vuetify.breakpoint.mdAndUp">
-        <template  v-for="(item, index) in menuItems">
+        <template  v-for="(item, index) in mainMenu">
 
           <!-- button path/gcode -->
           <div class="pa-1" :key="`btn-${index}`">
@@ -163,7 +163,7 @@ textarea {
 import Piecon from 'piecon'
 import { mapState, mapGetters, mapActions } from 'vuex'
 
-import { Menu, Routes } from './routes'
+import { Routes } from './routes'
 import { isPrinting } from './store/machine/modelEnums.js'
 import { MachineMode } from './store/machine/modelEnums.js';
 import { DashboardMode } from './store/settings.js'
@@ -187,9 +187,7 @@ export default {
 		...mapState('settings',['dashboardMode']),
 		...mapGetters('machine', ['hasTemperaturesToDisplay']),
 		...mapGetters('machine/model', ['jobProgress']),
-    menuItems() {
-			return Menu;
-		},
+		...mapGetters('mainMenu', ['mainMenu']),
 		currentPageCondition() {
 			const currentRoute = this.$route;
 			let checkRoute = function(route, isChild) {

--- a/src/routes/Control/Console.vue
+++ b/src/routes/Control/Console.vue
@@ -20,13 +20,10 @@ export default {
 	install() {
 		// Register a route via Control -> Console
 		registerRoute(this, {
-			Control: {
-				Console: {
-					icon: 'mdi-code-tags',
-					caption: 'menu.control.console',
-					path: '/Console'
-				}
-			}
+      key: 'control-console',
+      icon: 'mdi-code-tags',
+      caption: 'menu.control.console',
+      path: '/Console'
 		});
 	},
 	methods: mapMutations(['hideCodeReplyNotifications', 'showCodeReplyNotifications']),

--- a/src/routes/Control/Dashboard.vue
+++ b/src/routes/Control/Dashboard.vue
@@ -31,13 +31,10 @@ export default {
 	install() {
 		// Register a route via Control -> Dashboard
 		registerRoute(this, {
-			Control: {
-				Dashboard: {
-					icon: 'mdi-view-dashboard',
-					caption: 'menu.control.dashboard',
-					path: '/'
-				}
-			}
+        key: 'control-dashboard',
+        icon: 'mdi-view-dashboard',
+        caption: 'menu.control.dashboard',
+        path: '/'
 		});
 	}
 };

--- a/src/routes/Files/Filaments.vue
+++ b/src/routes/Files/Filaments.vue
@@ -15,13 +15,10 @@ export default {
 	install() {
 		// Register a route via Files -> Filaments
 		registerRoute(this, {
-			Files: {
-				Filaments: {
-					icon: 'mdi-database',
-					caption: 'menu.files.filaments',
-					path: '/Files/Filaments'
-				}
-			}
+      key: 'files-filaments',
+      icon: 'mdi-database',
+      caption: 'menu.files.filaments',
+      path: '/Files/Filaments'
 		});
 	}
 }

--- a/src/routes/Files/Jobs.vue
+++ b/src/routes/Files/Jobs.vue
@@ -15,13 +15,10 @@ export default {
 	install() {
 		// Register a route via Files -> Jobs
 		registerRoute(this, {
-			Files: {
-				Jobs: {
-					icon: 'mdi-play',
-					caption: 'menu.files.jobs',
-					path: '/Files/Jobs'
-				}
-			}
+      key: 'files-jobs',
+      icon: 'mdi-play',
+      caption: 'menu.files.jobs',
+      path: '/Files/Jobs'
 		});
 	}
 }

--- a/src/routes/Files/Macros.vue
+++ b/src/routes/Files/Macros.vue
@@ -15,13 +15,10 @@ export default {
 	install() {
 		// Register a route via Files -> Macros
 		registerRoute(this, {
-			Files: {
-				Macros: {
-					icon: 'mdi-polymer',
-					caption: 'menu.files.macros',
-					path: '/Files/Macros'
-				}
-			}
+      key: 'files-macros',
+      icon: 'mdi-polymer',
+      caption: 'menu.files.macros',
+      path: '/Files/Macros'
 		});
 	}
 }

--- a/src/routes/Files/System.vue
+++ b/src/routes/Files/System.vue
@@ -15,13 +15,10 @@ export default {
 	install() {
 		// Register a route via Files -> System
 		registerRoute(this, {
-			Files: {
-				System: {
-					icon: 'mdi-cog',
-					caption: 'menu.files.system',
-					path: '/Files/System'
-				}
-			}
+      key: 'files-system',
+      icon: 'mdi-cog',
+      caption: 'menu.files.system',
+      path: '/Files/System'
 		});
 	}
 }

--- a/src/routes/Job/Status.vue
+++ b/src/routes/Job/Status.vue
@@ -87,13 +87,10 @@ export default {
 	install() {
 		// Register a route via Job -> Status
 		registerRoute(this, {
-			Job: {
-				Status: {
-					icon: 'mdi-information',
-					caption: 'menu.job.status',
-					path: '/Job/Status'
-				}
-			}
+      key: 'job-status',
+      icon: 'mdi-information',
+      caption: 'menu.job.status',
+      path: '/Job/Status'
 		});
 	}
 }

--- a/src/routes/Job/Webcam.vue
+++ b/src/routes/Job/Webcam.vue
@@ -16,14 +16,11 @@ export default {
 	install() {
 		// Register a route via Job -> Webcam
 		registerRoute(this, {
-			Job: {
-				Webcam: {
-					icon: 'mdi-webcam',
-					caption: 'menu.job.webcam',
-					path: '/Job/Webcam',
-					condition: () => store.state.settings.webcam.url !== ''
-				}
-			}
+      key: 'job-webcam',
+      icon: 'mdi-webcam',
+      caption: 'menu.job.webcam',
+      path: '/Job/Webcam',
+      condition: () => store.state.settings.webcam.url !== ''
 		});
 	}
 }

--- a/src/routes/Settings/General.vue
+++ b/src/routes/Settings/General.vue
@@ -21,13 +21,10 @@ export default {
 	install() {
 		// Register a route via Settings -> General
 		registerRoute(this, {
-			Settings: {
-				General: {
-					icon: 'mdi-tune',
-					caption: 'menu.settings.general',
-					path: '/Settings/General'
-				}
-			}
+      key: 'settings-general',
+      icon: 'mdi-tune',
+      caption: 'menu.settings.general',
+      path: '/Settings/General'
 		});
 	},
 	data() {

--- a/src/routes/Settings/Machine.vue
+++ b/src/routes/Settings/Machine.vue
@@ -21,13 +21,10 @@ export default {
 	install() {
 		// Register a route via Settings -> Machine
 		registerRoute(this, {
-			Settings: {
-				Machine: {
-					icon: 'mdi-cogs',
-					caption: 'menu.settings.machine',
-					path: '/Settings/Machine'
-				}
-			}
+      key: 'settings-machine',
+      icon: 'mdi-cogs',
+      caption: 'menu.settings.machine',
+      path: '/Settings/Machine'
 		});
 	},
 	data() {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -122,7 +122,6 @@ export function registerSettingTab(general, name, component, caption, translated
 	}
 }
 
-
 // Control
 Vue.use(Dashboard)
 Vue.use(Console)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -93,49 +93,51 @@ function registerRouteInternal(menu, component, route) {
 	const keys = Object.keys(route);
 	const subRoute = route[keys[0]];
 
-	if (subRoute.path !== undefined) {
-		// This is the route we've been looking for
-		if (Routes.indexOf(subRoute) >= 0) {
-			return;
-		}
+	// Error if no path!
+	if (subRoute.path === undefined) {
+		throw new Error('Invalid route argument');
+	}
 
-		const routeObj = {
-			...subRoute,
-			component
-		};
-
-		// Prepare the actual route object
-		if (routeObj.caption instanceof Function) {
-			delete routeObj.caption;
-			Object.defineProperty(routeObj, 'caption', {
-				get: subRoute.caption
-			});
-		}
-
-		if (routeObj.condition === undefined) {
-			routeObj.condition = true;
-		} else {
-			routeObj.condition = undefined;
-			Object.defineProperty(routeObj, 'condition', {
-				get: subRoute.condition
-			});
-		}
-
-		if (routeObj.translated === undefined) {
-			routeObj.translated = false;
-		}
-
-		// Register the new route
-		if (menu.pages !== undefined) {
-			menu.pages.push(routeObj);
-		} else {
-			menu[keys[0]] = routeObj;
-		}
-		Routes.push(routeObj);
-		router.addRoute(routeObj);
+	// This is the route we've been looking for
+	if (Routes.indexOf(subRoute) >= 0) {
 		return;
 	}
-	throw new Error('Invalid route argument');
+
+	const routeObj = {
+		...subRoute,
+		component
+	};
+
+	// Prepare the actual route object
+	if (routeObj.caption instanceof Function) {
+		delete routeObj.caption;
+		Object.defineProperty(routeObj, 'caption', {
+			get: subRoute.caption
+		});
+	}
+
+	if (routeObj.condition === undefined) {
+		routeObj.condition = true;
+	} else {
+		routeObj.condition = undefined;
+		Object.defineProperty(routeObj, 'condition', {
+			get: subRoute.condition
+		});
+	}
+
+	if (routeObj.translated === undefined) {
+		routeObj.translated = false;
+	}
+
+	// Register the new route
+	if (menu.pages !== undefined) {
+		menu.pages.push(routeObj);
+	} else {
+		menu[keys[0]] = routeObj;
+	}
+	Routes.push(routeObj);
+	router.addRoute(routeObj);
+
 }
 
 export const GeneralSettingTabs = Vue.observable([])

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -22,10 +22,6 @@ import Machine from './Settings/Machine.vue'
 import Page404 from './Page404.vue'
 
 
-// menu starts with a safe clone out of the settings state...
-let cachedMenuJsonString = JSON.stringify(store.getters['settings/mainMenuConfig']);
-export const Menu = Vue.observable(JSON.parse(cachedMenuJsonString))
-
 export const Routes = []
 
 Vue.use(VueRouter)
@@ -35,10 +31,6 @@ const router = new VueRouter({
 	base: process.env.BASE_URL,
 	routes: Routes
 });
-
-// when a system component registers, keep the deets so we can re-inject after the settings update
-const keyedMenuItems = [];
-
 
 // Register a new route and menu item
 // component: Component to register
@@ -92,54 +84,12 @@ function registerRouteInternal(component, route) {
 		routeObj.translated = false;
 	}
 
-	injectIntoMenu({ routeObj, routeConfig, namedMenuGroup });
-
-	if (route.key) {
-		// system/internal components have keys, so we can reload them when config is updated
-		keyedMenuItems.push({ routeObj, routeConfig });
-	}
+	// push it into the menu itself...
+	store.commit('mainMenu/setMenuItem', { routeObj, routeConfig, namedMenuGroup });
 
 	Routes.push(routeObj);
 	router.addRoute(routeObj);
 }
-
-/**
- * Main menu starts out by default as categories, this will seek through the menu
- * and place the items under the named groups.
- *
- * The configuration however can be changed, where string placeholders are replaced
- * by actual components when/if they turn up. So in the configuration, place the
- * path for what will be a plugin's path, and when it's injected into the menu,
- * this will fine that string and set th menu item.
- */
-function injectIntoMenu({ routeObj, routeConfig, namedMenuGroup }) {
-	let placed = false;
-	// place into the menu
-	Menu.forEach((item, k) => {
-		if (typeof item === 'string' && (item === routeConfig.key || item === routeConfig.path)) {
-			// replace a string placeholder of top-level button/item (no submenu)
-			Menu[k] = routeObj;
-			placed = true;
-
-		} else if (item.pages) {
-			// place into a submenu
-			let idx = -1;
-			if (routeConfig.key) idx = (item.pages || []).indexOf(routeConfig.key);
-			if (idx < 0) idx = (item.pages || []).indexOf(routeConfig.path);
-			if (idx > -1) {
-				item.pages[idx] = routeObj;
-				placed = true;
-			}
-		}
-	});
-
-	if (!placed && namedMenuGroup) {
-		// backwards compatibility for existing plugins to inject
-		let group = Menu.find(item => item.name === namedMenuGroup);
-		if (group) group.pages.push(routeObj);
-	}
-}
-
 
 export const GeneralSettingTabs = Vue.observable([])
 export const MachineSettingTabs = Vue.observable([])
@@ -171,37 +121,6 @@ export function registerSettingTab(general, name, component, caption, translated
 		MachineSettingTabs.push(tab);
 	}
 }
-
-// Menu config updates, so we need to reset the menu and load
-// it back in as if it was configured that way originally...
-store.subscribe((mutation) => {
-	if (mutation.type === 'settings/load' && mutation.payload.mainMenuConfig && mutation.payload.mainMenuConfig.length) {
-		let tmpString = JSON.stringify(mutation.payload.mainMenuConfig);
-
-		if (tmpString === cachedMenuJsonString) {
-			// nothing changed in the menu, abort updates...
-			return;
-		}
-
-		// quick clear-out of the menu
-		for (const item of Menu) {
-			if (item.pages) {
-				while (item.pages.length > 0) item.pages.pop();
-			}
-		}
-		while (Menu.length > 0) {
-			Menu.pop();
-		}
-
-		// set the new configuration...
-		cachedMenuJsonString = tmpString;
-		let newStart = JSON.parse(tmpString);
-		newStart.forEach(item => Menu.push(item));
-
-		// re-attach the system components
-		keyedMenuItems.forEach(c => injectIntoMenu(c));
-	}
-});
 
 
 // Control

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -91,57 +91,49 @@ export function registerRoute(component, route) {
 
 function registerRouteInternal(menu, component, route) {
 	const keys = Object.keys(route);
-	if (keys.length === 1) {
-		const subRoute = route[keys[0]];
-		if (subRoute.path !== undefined) {
-			// This is the route we've been looking for
-			if (Routes.indexOf(subRoute) >= 0) {
-				return;
-			}
+	const subRoute = route[keys[0]];
 
-			const routeObj = {
-				...subRoute,
-				component
-			};
-
-			// Prepare the actual route object
-			if (routeObj.caption instanceof Function) {
-				delete routeObj.caption;
-				Object.defineProperty(routeObj, 'caption', {
-					get: subRoute.caption
-				});
-			}
-
-			if (routeObj.condition === undefined) {
-				routeObj.condition = true;
-			} else {
-				routeObj.condition = undefined;
-				Object.defineProperty(routeObj, 'condition', {
-					get: subRoute.condition
-				});
-			}
-
-			if (routeObj.translated === undefined) {
-				routeObj.translated = false;
-			}
-
-			// Register the new route
-			if (menu.pages !== undefined) {
-				menu.pages.push(routeObj);
-			} else {
-				menu[keys[0]] = routeObj;
-			}
-			Routes.push(routeObj);
-			router.addRoute(routeObj);
+	if (subRoute.path !== undefined) {
+		// This is the route we've been looking for
+		if (Routes.indexOf(subRoute) >= 0) {
 			return;
-		} else {
-			// Go one level deeper
-			const subCategory = menu[keys[0]];
-			if (subCategory !== undefined) {
-				registerRouteInternal(subCategory, component, subRoute);
-				return;
-			}
 		}
+
+		const routeObj = {
+			...subRoute,
+			component
+		};
+
+		// Prepare the actual route object
+		if (routeObj.caption instanceof Function) {
+			delete routeObj.caption;
+			Object.defineProperty(routeObj, 'caption', {
+				get: subRoute.caption
+			});
+		}
+
+		if (routeObj.condition === undefined) {
+			routeObj.condition = true;
+		} else {
+			routeObj.condition = undefined;
+			Object.defineProperty(routeObj, 'condition', {
+				get: subRoute.condition
+			});
+		}
+
+		if (routeObj.translated === undefined) {
+			routeObj.translated = false;
+		}
+
+		// Register the new route
+		if (menu.pages !== undefined) {
+			menu.pages.push(routeObj);
+		} else {
+			menu[keys[0]] = routeObj;
+		}
+		Routes.push(routeObj);
+		router.addRoute(routeObj);
+		return;
 	}
 	throw new Error('Invalid route argument');
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import i18n from '../i18n'
 import Root from '../main.js'
 import observer from './observer.js'
 import settings from './settings.js'
+import mainMenu from './mainMenu.js'
 import Plugins, { checkVersion, loadDwcResources } from '../plugins'
 import { InvalidPasswordError } from '../utils/errors.js'
 import Events from '../utils/events.js'
@@ -71,6 +72,8 @@ const store = new Vuex.Store({
 
 				await dispatch('machine/settings/load');
 				await dispatch('machine/cache/load');
+				await dispatch('mainMenu/load');
+
 				if (state.isLocal) {
 					commit('settings/setLastHostname', hostname);
 				}
@@ -254,7 +257,8 @@ const store = new Vuex.Store({
 			}
 		},
 		settings,
-		uiInjection
+		uiInjection,
+		mainMenu
 	},
 	plugins: [
 		connector.installStore,

--- a/src/store/mainMenu.js
+++ b/src/store/mainMenu.js
@@ -1,0 +1,146 @@
+'use strict'
+
+import Path from "@/utils/path";
+
+// As the internal page/menu-items come in, remember them so they can be squirted back into the menu
+// after the config file has been fetched from the server
+const keyedMenuItems = [];
+
+export default {
+	namespaced: true,
+	state: {
+		mainMenu: [                                      // Menu, initial configuration:
+			{                                            //   Strings in 'pages' arrays are the keys of
+				name: 'Control',                         //   the default system pages that are replaced
+				icon: 'mdi-tune',                        //   when the components register themselves
+				caption: 'menu.control.caption',
+				pages: [
+					'control-dashboard',
+					'control-console'
+				]
+			},
+			{
+				name: 'Job',
+				icon: 'mdi-printer',
+				caption: 'menu.job.caption',
+				pages: [
+					'job-status',
+					'job-webcam'
+				]
+			},
+			{
+				name: 'Files',
+				icon: 'mdi-sd',
+				caption: 'menu.files.caption',
+				pages: [
+					'files-jobs',
+					'files-macros',
+					'files-filaments',
+					'files-system'
+				]
+			},
+			{
+				name: 'Plugins',
+				icon: 'mdi-puzzle',
+				caption: 'menu.plugins.caption',
+				pages: []
+			},
+			{
+				name: 'Settings',
+				icon: 'mdi-wrench',
+				caption: 'menu.settings.caption',
+				pages: [
+					'settings-general',
+					'settings-machine'
+				]
+			}
+		]
+	},
+
+	getters: {
+		mainMenu: state => state.mainMenu
+	},
+
+	actions: {
+		async load({ commit, dispatch }) {
+			try {
+				const configContents = await dispatch('machine/download', {
+					filename: Path.dwcMainMenuFile,
+					showProgress: false,
+					showSuccess: false,
+					showError: false
+				}, {root: true});
+
+				if (!(configContents || []).length) return;
+
+				commit('resetMenu', configContents);
+
+				// re-attach the system components
+				keyedMenuItems.forEach(c => commit('setMenuItem', c));
+
+			} catch (e) {
+				// dissolve the error, file not being there or loading is fine...
+			}
+		}
+	},
+
+	mutations: {
+		/**
+		 * Main menu starts out by default as categories, this will seek through the menu
+		 * and place the items under the named groups.
+		 *
+		 * The configuration however can be changed, where string placeholders are replaced
+		 * by actual components when/if they turn up. So in the configuration, place the
+		 * path for what will be a plugin's path, and when it's injected into the menu,
+		 * this will fine that string and set th menu item.
+		*/
+		setMenuItem (state, { routeObj, routeConfig, namedMenuGroup }) {
+			if (routeConfig.key) {
+				keyedMenuItems.push({ routeObj, routeConfig });
+			}
+
+			let placed = false;
+			// place into the menu
+			state.mainMenu.forEach((item, k) => {
+				if (typeof item === 'string' && (item === routeConfig.key || item === routeConfig.path)) {
+					// replace a string placeholder of top-level button/item (no submenu)
+					state.mainMenu[k] = routeObj;
+					placed = true;
+
+				} else if (item.pages) {
+					// place into a submenu
+					let idx = -1;
+					if (routeConfig.key) idx = (item.pages || []).indexOf(routeConfig.key);
+					if (idx < 0) idx = (item.pages || []).indexOf(routeConfig.path);
+					if (idx > -1) {
+						item.pages[idx] = routeObj;
+						placed = true;
+					}
+				}
+			});
+
+			if (!placed && namedMenuGroup) {
+				// backwards compatibility for existing plugins to inject
+				let group = state.mainMenu.find(item => item.name === namedMenuGroup);
+				if (group) group.pages.push(routeObj);
+			}
+		},
+
+		resetMenu (state, freshConfig) {
+			// quick clear-out of the menu
+			for (const item of state.mainMenu) {
+				if (item.pages) {
+					while (item.pages.length > 0) item.pages.pop();
+				}
+			}
+			while (state.mainMenu.length > 0) {
+				state.mainMenu.pop();
+			}
+
+			freshConfig.forEach(item => {
+				console.log(item);
+				state.mainMenu.push(item)
+			});
+		}
+	}
+}

--- a/src/store/mainMenu.js
+++ b/src/store/mainMenu.js
@@ -138,7 +138,6 @@ export default {
 			}
 
 			freshConfig.forEach(item => {
-				console.log(item);
 				state.mainMenu.push(item)
 			});
 		}

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -53,8 +53,16 @@ export default {
 				caption: 'menu.control.caption',
 				pages: [
 					'control-dashboard',
-					'control-console',
-					'job-status'
+					'control-console'
+				]
+			},
+			{
+				name: 'Job',
+				icon: 'mdi-printer',
+				caption: 'menu.job.caption',
+				pages: [
+					'job-status',
+					'job-webcam'
 				]
 			},
 			{
@@ -63,6 +71,8 @@ export default {
 				caption: 'menu.files.caption',
 				pages: [
 					'files-jobs',
+					'files-macros',
+					'files-filaments',
 					'files-system'
 				]
 			},

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -44,7 +44,47 @@ export default {
 		dashboardMode : DashboardMode.default,
 
 		enabledPlugins: ['Height Map'],
-		plugins: {},										// Third-party values
+		plugins: {},							         // Third-party values
+
+		mainMenu: [                                      // Menu, initial configuration:
+			{                                            //   Strings in 'pages' arrays are the keys of
+				name: 'Control',                         //   the default system pages that are replaced
+				icon: 'mdi-tune',                        //   when the components register themselves
+				caption: 'menu.control.caption',
+				pages: [
+					'control-dashboard',
+					'control-console',
+					'job-status'
+				]
+			},
+			{
+				name: 'Files',
+				icon: 'mdi-sd',
+				caption: 'menu.files.caption',
+				pages: [
+					'files-jobs',
+					'files-system'
+				]
+			},
+			{
+				name: 'Plugins',
+				icon: 'mdi-puzzle',
+				caption: 'menu.plugins.caption',
+				pages: []
+			},
+			{
+				name: 'Settings',
+				icon: 'mdi-wrench',
+				caption: 'menu.settings.caption',
+				pages: [
+					'settings-general',
+					'settings-machine'
+				]
+			}
+		]
+	},
+	getters: {
+		mainMenuConfig: state => state.mainMenu
 	},
 	actions: {
 		async applyDefaults({ state, dispatch }) {

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -44,72 +44,9 @@ export default {
 		dashboardMode : DashboardMode.default,
 
 		enabledPlugins: ['Height Map'],
-		plugins: {},							         // Third-party values
-
-		mainMenu: [                                      // Menu, initial configuration:
-			{                                            //   Strings in 'pages' arrays are the keys of
-				name: 'Control',                         //   the default system pages that are replaced
-				icon: 'mdi-tune',                        //   when the components register themselves
-				caption: 'menu.control.caption',
-				pages: [
-					'control-dashboard',
-					'control-console'
-				]
-			},
-			{
-				name: 'Job',
-				icon: 'mdi-printer',
-				caption: 'menu.job.caption',
-				pages: [
-					'job-status',
-					'job-webcam'
-				]
-			},
-			{
-				name: 'Files',
-				icon: 'mdi-sd',
-				caption: 'menu.files.caption',
-				pages: [
-					'files-jobs',
-					'files-macros',
-					'files-filaments',
-					'files-system'
-				]
-			},
-			{
-				name: 'Plugins',
-				icon: 'mdi-puzzle',
-				caption: 'menu.plugins.caption',
-				pages: []
-			},
-			{
-				name: 'Settings',
-				icon: 'mdi-wrench',
-				caption: 'menu.settings.caption',
-				pages: [
-					'settings-general',
-					'settings-machine'
-				]
-			}
-		]
-	},
-	getters: {
-		mainMenuConfig: state => state.mainMenu
+		plugins: {} 							        // Third-party values
 	},
 	actions: {
-		async applyDefaults({ state, dispatch }) {
-			// Load settings that are enabled by default
-			if (state.enabledPlugins) {
-				for (let i = 0; i < state.enabledPlugins.length; i++) {
-					try {
-						await dispatch('loadDwcPlugin', { id: state.enabledPlugins[i], saveSettings: false }, { root: true });
-					} catch (e) {
-						console.warn(`Failed to load built-in plugin ${state.enabledPlugins[i]}`);
-						console.warn(e);
-					}
-				}
-			}
-		},
 		async load({ rootState, rootGetters, commit, dispatch }) {
 			// First attempt to load the last hostname from the local storage if the are running on localhost
 			if (rootState.isLocal) {

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -162,6 +162,7 @@ const pathObj = {
 	dwcFactoryDefaults: '0:/sys/dwc-defaults.json',
 	legacyDwcFactoryDefaults: '0:/sys/dwc2-defaults.json',
 	dwcPluginsFile: '0:/sys/dwc-plugins.json',
+	dwcMainMenuFile: '0:/sys/dwc-mainMenu.json',
 
 	boardFile: '0:/sys/board.txt',
 	configFile: 'config.g',


### PR DESCRIPTION
Was just an idea that maybe a main menu that's configurable could be handy for people, based on a forum thread, and that I was using a hacked up menu myself on my CNC machine.

Note: I'm a rando coder nobody knows about, and I have no idea if should I set this up to PR into dev or the beta branch, or whatever branch, just selecting the latest. Let me know if it should be set up some other way, or if there's no chance, or whatever :)

This moves the configuration to the store vuex, as well as changing the configuration to work off of string placeholders in the configuration, to be replaced by the internal components replacing the placeholders by looking for a key. Users can configure the menu they're after by defining the structure of these placeholders. To do this, the groupings (Control, Files, etc) are a json structure with a name, can can also be requested by how components previously registered themselves with the structure (the route config components used to provide work as a kind of suggestion, looking for the group as named, or if specifically placed by path reference, can be over-ruled by that mechanism).

Edit: the configuration was buried in `store/settings.js` but the implications of how it updates required more code. I move it all to `mainMenu.js`, that contains all the hassle, leaving the rest cleaner... this did mean that the config is in a `dwc-mainMenu.json` file, that if it's not found/404'd it just ignores it and uses the default from the script itself.

The internal/system components are registered and routed before the json file is downloaded, so there's a little clearing out of the menu when it does download so that it can set it back up based on the configuration.


Examples:

This replicates the default structure, with the key placeholders that will be replaced by the component route registrations (look for the keys in each of the page level components). Note that this is what is used if nothing is custom configured...

```
		mainMenu: [
			{
				name: 'Control',
				icon: 'mdi-tune',
				caption: 'menu.control.caption',
				pages: [
					'control-dashboard',
					'control-console'
				]
			},
			{
				name: 'Job',
				icon: 'mdi-printer',
				caption: 'menu.job.caption',
				pages: [
					'job-status',
					'job-webcam'
				]
			},
			{
				name: 'Files',
				icon: 'mdi-sd',
				caption: 'menu.files.caption',
				pages: [
					'files-jobs',
					'files-macros',
					'files-filaments',
					'files-system'
				]
			},
			{
				name: 'Plugins',
				icon: 'mdi-puzzle',
				caption: 'menu.plugins.caption',
				pages: []
			},
			{
				name: 'Settings',
				icon: 'mdi-wrench',
				caption: 'menu.settings.caption',
				pages: [
					'settings-general',
					'settings-machine'
				]
			}
		]
```


The paths of the page components also work, including paths for installed plugins. Here is an example of a flat menu with no groups, but also a custom plugin ("/MoveItMoveIt" is my own plugin's path). If the user saved this to the `dwc-mainMenu.json` file, it would load when the settings is downloaded off SD...


```
{ "mainMenu": [
			'/MoveItMoveIt',
			'control-console',
			'job-status',
			'job-webcam',
			'files-jobs',
			'files-macros',
			'files-filaments',
			'files-system',
			'settings-general',
			'settings-machine'
		]
}
```

The configuration does allow for a complext structure type that sets up a custom item in the menu, with a manually configured routing path (which is pushed to the VueJS router when clicked), that sets the text, icon, and with an option to render it more like a button ("button":true) rather than the list-item. Here is an example of item configs that makes a custom titled link to the dashboard (translation works if the user uses a translation key, but otherwise just uses the String, which is the current system behavior anyway (nothing new here)), and the second item is rendered as a button, and fires a home gcode (people could make a handy menu-based macro set of buttons... only because it's easy enough, and why not? :) )...

```
	  { "caption": "Extra Dashboard!", "icon": "mdi-wrench", "path": "/", "button": true },
	  { "caption": "Home Sweet Home!", "icon": "mdi-tune", "gcode": "G28", "color": "warning", "button": true },
```