### PR TITLE
Fixed misspelled plugindir variable

### DIFF
--- a/scripts/build-plugin.js
+++ b/scripts/build-plugin.js
@@ -160,7 +160,7 @@ service
 			} else {
 				archive.pipe(fs.createWriteStream(distDir + `/${pluginManifest.id}-${pluginManifest.version}.zip`));
 			}
-			archive.on('warning', function(err) {
+			archive.on('warning', function (err) {
 				if (err.code === 'ENOENT') {
 					warn(err);
 				} else {
@@ -168,11 +168,11 @@ service
 					process.exit(1);
 				}
 			});
-			archive.on('error', function(err) {
+			archive.on('error', function (err) {
 				error(err);
 				process.exit(1);
 			});
-			archive.on('end', function() {
+			archive.on('end', function () {
 				done(`Plugin ZIP file written to dist/${pluginManifest.id}-${pluginManifest.version}.zip`);
 			});
 
@@ -211,15 +211,15 @@ service
 
 			// Add optional assets to plugin ZIP
 			if (fs.existsSync(pluginDir + '/dsf/')) {
-				archive.directory(plugindir + '/dsf', 'dsf');
+				archive.directory(pluginDir + '/dsf', 'dsf');
 				filesAdded = true;
 			}
 			if (fs.existsSync(pluginDir + '/dwc/')) {
-				archive.directory(plugindir + '/dwc', 'dwc');
+				archive.directory(pluginDir + '/dwc', 'dwc');
 				filesAdded = true;
 			}
 			if (fs.existsSync(pluginDir + '/sd/')) {
-				archive.directory(plugindir + '/sd', 'sd');
+				archive.directory(pluginDir + '/sd', 'sd');
 				filesAdded = true;
 			}
 


### PR DESCRIPTION
When having `dsf/` in my plugin (for instance for the Python backend), after building the plugin using the [new automated build script](https://github.com/Duet3D/DuetWebControl/blob/v3.4-dev/scripts/build-plugin.js), it'll throw the following error: ![Screenshot from 2021-11-22 17-38-39](https://user-images.githubusercontent.com/1212814/142939906-07d58780-c30f-403b-be72-6ad71077a0b6.png)

I fixed it by renaming the variable `plugindir` to `pluginDir`.

It never failed before on the [demo plugin](https://github.com/Duet3D/DSF-Plugins/tree/dev/EndstopsMonitor) since (at the time of writing, at least) it only contains DWC-related sources (the VueJS stuff) and this part builds fine.

I hope this is enough info for the fix, and let me know if there are any questions. I wish you all a pleasant day!