### PR TITLE
Add a check to verify 12v is not null

### DIFF
--- a/src/components/panels/CNCContainerPanel.vue
+++ b/src/components/panels/CNCContainerPanel.vue
@@ -55,7 +55,7 @@
 										</v-tooltip>
 									</v-col>
 
-									<v-col class="d-flex flex-column align-center" v-if="boards.length && boards[0].v12.current > 0">
+									<v-col class="d-flex flex-column align-center" v-if="boards.length && boards[0].v12 !== null && boards[0].v12.current > 0">
 										<strong>{{ $t('panel.status.v12') }}</strong>
 										<v-tooltip bottom>
 											<template #activator="{ on }">


### PR DESCRIPTION
The CNC Dashboard was not displaying on any board that did not have a 12v value reporting. This fix checks if 12v is null to avoid an exception being thrown.