### PR TITLE
Add two options - decimalPlaces and displayUnits

### DIFF
--- a/src/components/panels/CNCAxesPosition.vue
+++ b/src/components/panels/CNCAxesPosition.vue
@@ -21,9 +21,9 @@
 </style>
 
 <template>
-	<v-card>
+	<v-card class="py-0">
 		<v-card-title class="py-2">
-			<strong>{{ machinePosition ? $t('panel.status.machinePosition') : $t('panel.status.toolPosition') }} </strong>
+			<strong>{{ topTitle }} </strong>
 		</v-card-title>
 		<v-card-text>
 			<v-row align-content="center" no-gutters :class="{'large-font' : !machinePosition}">
@@ -44,6 +44,7 @@
 'use strict'
 
 import { mapState } from 'vuex';
+import { UnitOfMeasure } from '../../store/settings';
 
 export default {
     props: {
@@ -53,18 +54,26 @@ export default {
         }
     },
     computed: {
+		...mapState('settings', ['displayUnits', 'decimalPlaces']),
         ...mapState('machine/model', {
             move: state => state.move,
             status: state => state.state.status,
         }),
         visibleAxes() {
             return this.move.axes.filter(axis => axis.visible);
-        }
+        },
+		topTitle() {
+			// place the current unit of measure next to the title
+			let suffix = this.$t((this.displayUnits == UnitOfMeasure.imperial) ? 'panel.settingsAppearance.unitInches' : 'panel.settingsAppearance.unitMm');
+			return this.$t(this.machinePosition ? 'panel.status.machinePosition' : 'panel.status.toolPosition') + 
+						' ('  + suffix + ')';
+		}
     },
     methods: {
         displayAxisPosition(axis) {
-            const position = this.machinePosition ? axis.machinePosition : axis.userPosition;
-            return axis.letter === 'Z' ? this.$displayZ(position, false) : this.$display(position, 1);
+            const position = (this.machinePosition ? axis.machinePosition : axis.userPosition) /
+							((this.displayUnits == UnitOfMeasure.imperial) ? 25.4 : 1);
+			return axis.letter === 'Z' ? this.$displayZ(position, false) : this.$display(position, this.decimalPlaces);
         }
     }
 }

--- a/src/components/panels/CNCContainerPanel.vue
+++ b/src/components/panels/CNCContainerPanel.vue
@@ -9,7 +9,7 @@
 		<v-row align="stretch" dense>
 			<v-col cols="3" lg="2" md="2" order="1" order-lg="1" sm="4">
 				<v-card class="justify-center fill-height">
-					<v-card-title>
+					<v-card-title class="py-2">
 						<strong>Status</strong>
 					</v-card-title>
 					<v-card-text>
@@ -22,18 +22,18 @@
 			</v-col>
 			<v-col cols="5" lg="3" md="3" order="2" order-lg="3" sm="4">
 				<v-card class="fill-height">
-					<v-card-title>
+					<v-card-title class="py-2">
 						<strong>Requested Speed</strong>
 					</v-card-title>
-					<v-card-text>{{ $display(move.currentMove.requestedSpeed, 0, 'mm/s') }}</v-card-text>
+					<v-card-text>{{ displaySpeed(move.currentMove.requestedSpeed) }}</v-card-text>
 				</v-card>
 			</v-col>
 			<v-col cols="4" lg="3" md="3" order="2" order-lg="4" sm="4">
 				<v-card class="fill-height" order="5">
-					<v-card-title>
+					<v-card-title class="py-2">
 						<strong>Top Speed</strong>
 					</v-card-title>
-					<v-card-text>{{ $display(move.currentMove.topSpeed, 0, 'mm/s') }}</v-card-text>
+					<v-card-text>{{ displaySpeed(move.currentMove.topSpeed) }}</v-card-text>
 				</v-card>
 			</v-col>
 			<v-col cols="12" order="6" v-if="sensorsPresent">
@@ -116,8 +116,10 @@
 <script>
 import {mapState} from 'vuex';
 import {ProbeType, isPrinting, AnalogSensorType} from '../../store/machine/modelEnums.js';
+import { UnitOfMeasure } from '../../store/settings.js';
 export default {
 	computed: {
+		...mapState('settings', ['displayUnits']),
 		...mapState('machine/model', {
 			move: (state) => state.move,
 			machineMode: (state) => state.state.machineMode,
@@ -157,9 +159,11 @@ export default {
 		},
 	},
 	methods: {
-		displayAxisPosition(axis) {
-			const position = this.displayToolPosition ? axis.userPosition : axis.machinePosition;
-			return axis.letter === 'Z' ? this.$displayZ(position, false) : this.$display(position, 1);
+		displaySpeed(speed) {
+			if(this.displayUnits == UnitOfMeasure.imperial) {
+				return this.$display(speed*60/25.4, 1, this.$t('panel.settingsAppearance.unitInchSpeed'));	// to ipm
+			}
+			return this.$display(speed, 1,  this.$t('panel.settingsAppearance.unitMmSpeed'));
 		},
 		formatProbeValue(values) {
 			if (values.length === 1) {

--- a/src/components/panels/SettingsAppearancePanel.vue
+++ b/src/components/panels/SettingsAppearancePanel.vue
@@ -21,6 +21,8 @@
 			<v-switch :label="$t('panel.settingsAppearance.bottomNavigation')" hide-details v-model="bottomNavigation"></v-switch>
 			<v-switch :label="$t('panel.settingsAppearance.numericInputs')" hide-details v-model="numericInputs"></v-switch>
 			<v-switch :label="$t('panel.settingsAppearance.iconMenu')" hide-details v-model="iconMenu"></v-switch>
+			<v-text-field v-model.number="decimalPlaces" type="number" step="any" min="0" :label="$t('panel.settingsAppearance.decimalPlaces')" hide-details></v-text-field>
+			<v-select :items="unitsofMeasure" :label="$t('panel.settingsAppearance.displayUnitsTitle')" class="mt-3" hide-details item-text="value" item-value="value" v-model="displayUnits"></v-select>
 		</v-card-text>
 	</v-card>
 </template>
@@ -31,6 +33,7 @@
 import { mapState, mapMutations } from 'vuex'
 
 import { DashboardMode } from '@/store/settings'
+import { UnitOfMeasure } from '../../store/settings';
 
 export default {
 	computed: {
@@ -38,6 +41,14 @@ export default {
 		darkTheme: {
 			get() { return this.settings.darkTheme; },
 			set(value) { this.update({ darkTheme: value }); }
+		},
+		decimalPlaces: {
+			get() { return this.settings.decimalPlaces; },
+			set(value) { this.update({ decimalPlaces: value }); }
+		},
+		displayUnits: {
+			get() { return this.settings.displayUnits; },
+			set(value) { this.update({displayUnits: value}); }
 		},
 		language: {
 			get() { return this.settings.language; },
@@ -72,6 +83,11 @@ export default {
 		dashboardModes() {
 			return Object.keys(DashboardMode).map((key) => {
 				return { key, value: DashboardMode[key] };
+			});
+		},
+		unitsofMeasure() {
+			return Object.keys(UnitOfMeasure).map((key) => {
+				return { key, value: UnitOfMeasure[key] };
 			});
 		},
 		bottomNavigation: {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -682,7 +682,14 @@ export default {
             dashboardModeTitle: 'Dashboard Mode',
             bottomNavigation: 'Show bottom navigation on tablet devices',
             numericInputs: 'Show numeric input fields instead of sliders',
-			iconMenu: 'Use compact icon menu'
+			iconMenu: 'Use compact icon menu',
+			decimalPlaces: 'Number of decimal points in coordinate display',
+			displayUnitsTitle: 'Display coordinate unit of measure',
+            unitInches: 'inches',
+            unitInch: 'in',
+            unitMm: 'mm',
+			unitInchSpeed: 'ipm',
+			unitMmSpeed: 'mm/s'
         },
         settingsCommunication: {
             caption: 'Communication',

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -16,6 +16,11 @@ export const DashboardMode = {
 	cnc: 'CNC'
 }
 
+export const UnitOfMeasure = {
+	metric: 'mm',
+	imperial: 'inch'
+}
+
 export default {
 	namespaced: true,
 	state: {
@@ -25,10 +30,12 @@ export default {
 		darkTheme: false,
 		useBinaryPrefix: true,
 		disableAutoComplete: false,
-        dashboardMode : DashboardMode.default,
+        dashboardMode: DashboardMode.default,
         bottomNavigation: true,
         numericInputs: false,
 		iconMenu: false,
+		displayUnits: UnitOfMeasure.metric,
+		decimalPlaces: 1,
 
 		settingsStorageLocal: false,
 		settingsSaveDelay: 500,							// ms - how long to wait before settings updates are saved

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,6 +4,7 @@ const ZipPlugin = require('zip-webpack-plugin')
 
 module.exports = {
 	configureWebpack: {
+		devtool: 'source-map',
 		externals: {
 			moment: 'moment'
 		},


### PR DESCRIPTION
 decimalPlaces determines how many decimal places are shown in the dashboard coordinate display

displayUnits determines what unit of measure (inch/mm) is used for those coordinates as well as what units are used for the speeds (mm/s or ipm)

these only affect displayed values