### PR TITLE
Improve UX for cancelling and resuming objects

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -964,7 +964,13 @@
       "useHQRendering": "High Quality Render (Round)",
       "useSpecular": "Use Specular Highlight",
       "feature": "Feature",
-      "g1AsExtrusion": "Render G1 (CNC)"
+      "g1AsExtrusion": "Render G1 (CNC)",
+      "objectDialog": {
+        "cancelTitle": "Cancel Object",
+        "resumeTitle": "Resume Object",
+        "cancelPrompt": "Are you sure you want to cancel this object? It can be resumed by selecting it again.",
+        "resumePrompt": "Are you sure you want to resume this object?"
+      }
     },
     "heightmap": {
       "menuCaption": "Height Map",

--- a/src/plugins/GCodeViewer/GCodeViewer.vue
+++ b/src/plugins/GCodeViewer/GCodeViewer.vue
@@ -337,16 +337,19 @@
 			<v-card>
 				<v-card-title class="headline">
 					<v-icon class="mr-2">{{ objectDialogData.info.cancelled ? 'mdi-reload' : 'mdi-cancel' }}</v-icon>
-					{{ objectDialogData.info.cancelled ? 'Resume' : 'Cancel' }} Object
+					{{ objectDialogData.info.cancelled ? $t('plugins.gcodeViewer.objectDialog.resumeTitle') : $t('plugins.gcodeViewer.objectDialog.cancelTitle') }}
 				</v-card-title>
-				<v-card-text>{{ objectDialogData.info.name }}</v-card-text>
+				<v-card-text>
+					<p class="text-h4 text--primary">{{ objectDialogData.info.name }}</p>
+					<div class="text--primary">{{ objectDialogData.info.cancelled ? $t('plugins.gcodeViewer.objectDialog.resumePrompt') : $t('plugins.gcodeViewer.objectDialog.cancelPrompt') }}</div>
+				</v-card-text>
 				<v-card-actions>
 					<v-row no-gutters>
 						<v-col cols="6">
-							<v-btn @click="objectDialogCancelObject" block color="primary">Ok</v-btn>
+							<v-btn @click="objectDialogCancelObject" block color="primary">{{$t('generic.yes')}}</v-btn>
 						</v-col>
 						<v-col cols="6">
-							<v-btn @click="objectDialogData.showDialog = false" block color="error">Cancel</v-btn>
+							<v-btn @click="objectDialogData.showDialog = false" block color="error">{{$t('generic.no')}}</v-btn>
 						</v-col>
 					</v-row>
 				</v-card-actions>


### PR DESCRIPTION
The current prompts for cancelling or resuming objects is a little ambiguous. When cancelling you get the options "Ok" and "Cancel", and both would logically mean "Yes, I want to cancel".

This PR changes them to "Yes", and "No", and adds an "Are you sure you want to cancel?" prompt.

Additionally, it changes the dialog to use i18n for the content.