### PR TITLE
Fix for plugins with SBC permissions requirement

### DIFF
--- a/src/components/dialogs/PluginInstallDialog.vue
+++ b/src/components/dialogs/PluginInstallDialog.vue
@@ -306,7 +306,7 @@ export default Vue.extend({
 		},
 
 		permissions(): Set<SbcPermission> {
-			return this.pluginManifest.sbcPermissions || new Set<SbcPermission>();
+			return new Set<SbcPermission>(this.pluginManifest.sbcPermissions || []);
 		}
 	},
 	data() {


### PR DESCRIPTION
`this.pluginManifest.sbcPermissions` is still an Array and not a Set as expected so when trying to install a plugin with SBC permission requirements, it fails because of `this.permissions.has(SbcPermission.superUser)` (Array has not `has` method).

Maybe a more proper fix would be to change the `initObject` from the ObjectModel TS library so `this.pluginManifest.sbcPermissions` is returned as `Set<SbcPermission>` type ?