### PR TITLE
Added nextTick=>return to registerCategory function

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -227,6 +227,8 @@ export function registerCategory(name: string, icon: string, caption: string | (
 		}
 
 		Vue.set(Menu, name, category);
+		//return on next tick to ensure dom/component is updated before plugin attempts to register new routes uner the new category
+		Vue.nextTick(() => {return;});
 	}
 }
 


### PR DESCRIPTION
If a plugin attempts to register a new menu category using 'registerCategory', and then immediately attempts to register routes for child components of the new menu category, the menu does not update on screen. By adding a nextTick=>return to the 'registerCategory' function, it ensures the DOM/Component is updated before the child components are added, and the menu is updated on screen as expected.