### PR TITLE
sets output for coordinates to two decimal places

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "duetwebcontrol",
-   "version": "3.5.0-rc.3+7",
+   "version": "3.5.0-rc.3+8",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "duetwebcontrol",
-         "version": "3.5.0-rc.3+7",
+         "version": "3.5.0-rc.3+8",
          "license": "GPL-3.0",
          "dependencies": {
             "@duet3d/motionanalysis": "^3.5.0-beta.1",

--- a/src/components/dialogs/MessageBoxDialog.vue
+++ b/src/components/dialogs/MessageBoxDialog.vue
@@ -150,7 +150,7 @@ export default Vue.extend({
 			if (axis.userPosition === null) {
 				return this.$t("generic.noValue");
 			}
-			return (axis.letter === AxisLetter.Z) ? this.$displayZ(axis.userPosition, false) : this.$display(axis.userPosition, 1);
+			return this.$displayZ(axis.userPosition, false);
 		},
 		getMoveCellClass(index: number): string {
 			let classes = "";

--- a/src/plugins/GCodeViewer/FSOverlay.vue
+++ b/src/plugins/GCodeViewer/FSOverlay.vue
@@ -90,7 +90,7 @@
 
 .axes-container-viewgcode {
 	position: fixed;
-	right: 50% 
+	right: 50%
 }
 
 .heater-container {
@@ -134,7 +134,7 @@ export default {
         viewgcode: {
             type: Boolean,
             default: false
-        }  
+        }
     },
     mounted() {
         this.$window
@@ -149,8 +149,8 @@ export default {
 	methods: {
 		displayAxisPosition(axis) {
 			const position = axis.userPosition;
-			return axis.letter === 'Z' ? this.$displayZ(position, false) : this.$display(position, 1);
-		},
+	    	return this.$displayZ(axis.userPosition, false);
+			},
 		getHeaterInfo(heaterIdx) {
 			return this.heat.heaters[heaterIdx];
 		},

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -38,7 +38,7 @@ export function displayAxisPosition(axis: Axis, machinePosition: boolean = false
 	}
 
 	position = position / ((store.state.settings.displayUnits === UnitOfMeasure.imperial) ? 25.4 : 1);
-	return axis.letter === AxisLetter.Z ? displayZ(position, false) : display(position, store.state.settings.decimalPlaces);
+	return displayZ(position, false);
 }
 
 /**
@@ -54,7 +54,7 @@ export function displayZ(value: number | Array<number> | string | null | undefin
 /**
  * Display a sensor value with optional unit from square brackets in the name
  * @param sensor Sensor
- * @returns 
+ * @returns
  */
 export function displaySensorValue(sensor: AnalogSensor) {
     if (sensor.name) {


### PR DESCRIPTION
As discussed a while back this change is crucial for the IDEX / multihead calibration. Impleneted in the PanelDue already.