### PR TITLE
Feature/gcodeviewer updates 3.7.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "duetwebcontrol",
-   "version": "3.6.0-beta.1",
+   "version": "3.6.0-beta.1+2",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "duetwebcontrol",
-         "version": "3.6.0-beta.1",
+         "version": "3.6.0-beta.1+2",
          "license": "GPL-3.0",
          "dependencies": {
             "@duet3d/connectors": "~3.6.0-beta.13",
@@ -14,7 +14,7 @@
             "@duet3d/motionanalysis": "^3.4.0",
             "@duet3d/objectmodel": "~3.6.0-alpha.1",
             "@mdi/font": "^7.4.47",
-            "@sindarius/gcodeviewer": "^3.7.11",
+            "@sindarius/gcodeviewer": "^3.7.13",
             "chart.js": "^2.9.4",
             "chartjs-adapter-date-fns": "^1.0.0",
             "date-fns": "^2.30.0",
@@ -2001,26 +2001,23 @@
          }
       },
       "node_modules/@babylonjs/core": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.27.0.tgz",
-         "integrity": "sha512-/GyZe1b0y/LfxAxX+i20Wtkr76fqah+OJZi2F5pgF/MSpm2KfJnSObeWqZDi01CAYM9zLXTfPiMupDdhUv54vw==",
-         "license": "Apache-2.0"
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.29.0.tgz",
+         "integrity": "sha512-uegeRE4kEjoiW8nXOszMTkz1jlx5ITTTZvDo5xjhPSa0GK9KhZ2IQF0JONEuJgBdJPtplrUXzH8VzqIE8GpY1g=="
       },
       "node_modules/@babylonjs/gui": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.27.0.tgz",
-         "integrity": "sha512-j3C8VZOcs9J6jNeF9WQTYJegLb+Vdjz7sFius7D5piz1aWsqS/MxehAjcHPzyJn6PS/7KNF+b3IdOoV7worElw==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.29.0.tgz",
+         "integrity": "sha512-oXEDrOAGV0YWYGUnHj7zb/QpKt7wtzebR4VlUOrPYhq1jYF5OK5r34hNMOsbx5j1elQAujNMCxMmGmnzJfc7mw==",
          "peer": true,
          "peerDependencies": {
             "@babylonjs/core": "^7.0.0"
          }
       },
       "node_modules/@babylonjs/gui-editor": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-7.27.0.tgz",
-         "integrity": "sha512-PenKRJIZbG+sVSXuVfayjjiDbpwcw4atZIQgrVJN4GqkQA6anC/YjXebMjob4pe+Qt8KkvjVjfgKYuUtGLNkXA==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-7.29.0.tgz",
+         "integrity": "sha512-+Vpig5Lr0KLngfhKDrUleEeUQxrs0yu4wVSkcRj5qEVscqm+jfAIldSMpx9kjUjsX1m7xG/tUYYaKgSDL15SpA==",
          "peer": true,
          "peerDependencies": {
             "@babylonjs/core": "^7.0.0",
@@ -2030,10 +2027,9 @@
          }
       },
       "node_modules/@babylonjs/inspector": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/inspector/-/inspector-7.27.0.tgz",
-         "integrity": "sha512-91pCyK+0NdPFQvTW4d11Wevm/DsTHvBBNTalq5/KgCYuqjpsNr3C8G0RMDLW4EOH6jllLGuu76lPgCKj+EblIQ==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/inspector/-/inspector-7.29.0.tgz",
+         "integrity": "sha512-FTVcO44Y3VDOh9YZ9I+XJPrc8e7+eoNwyPr5qVvS4hGCkxA84nUvAfKi1wrz+iKUv7HxjEjkz0ptIPLYbtHnxw==",
          "dependencies": {
             "@fortawesome/fontawesome-svg-core": "^6.1.0",
             "@fortawesome/free-regular-svg-icons": "^6.0.0",
@@ -2051,29 +2047,26 @@
          }
       },
       "node_modules/@babylonjs/loaders": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.27.0.tgz",
-         "integrity": "sha512-xBlVQ/m+UWhaMEn6q1j3ktu/GcrIxHEc9ybGOkOHst4Fk+5ebvFymjbscaQ20MEWa42Eue4x55rntDGUnCjYsw==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.29.0.tgz",
+         "integrity": "sha512-nAukPQ0Sy6okeAiTKPW21A3ftShxTpOtwWN6q4/CjPn1wPR04R3g/G2w40yF8jtTZji0MGgHSzcSTvMMb4pcaQ==",
          "peerDependencies": {
             "@babylonjs/core": "^7.0.0",
             "babylonjs-gltf2interface": "^7.0.0"
          }
       },
       "node_modules/@babylonjs/materials": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.27.0.tgz",
-         "integrity": "sha512-GbvOD/57UuI6u+6vdTwSIv/GlSdz0+EaR0CuEAvoopAIMiyRZAwrZgXYrXvsUo059cigh9t+wLDUMRDEjTjBnw==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.29.0.tgz",
+         "integrity": "sha512-1/dQj2mxVenN2yAig5l9vDBHSbu0FQkrWnEJDpxsEp4clcExs4nagtSF5X8DOz3GZeVr3+w+/RSebKpVzC2ALQ==",
          "peerDependencies": {
             "@babylonjs/core": "^7.0.0"
          }
       },
       "node_modules/@babylonjs/serializers": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.27.0.tgz",
-         "integrity": "sha512-ERx2a5iY5tnptwv4NVY4skwRAp7e/DZSWr7VpHEdVWXZ6QTN11WHeDLrJroo+F/S2tfnDubj+YB2G9I5SVG93Q==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.29.0.tgz",
+         "integrity": "sha512-bYgnGyT0wa+YVNILfv4sVU8613PnKyleQjqD04QWcC7FXR2WR30sfV6HSdimVazMUrJ8fNj5XRU+6iOM3sHTEQ==",
          "peer": true,
          "peerDependencies": {
             "@babylonjs/core": "^7.0.0",
@@ -2132,7 +2125,6 @@
          "version": "6.6.0",
          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
          "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
-         "license": "MIT",
          "engines": {
             "node": ">=6"
          }
@@ -2141,7 +2133,6 @@
          "version": "6.6.0",
          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
          "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
-         "license": "MIT",
          "dependencies": {
             "@fortawesome/fontawesome-common-types": "6.6.0"
          },
@@ -2153,7 +2144,6 @@
          "version": "6.6.0",
          "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.6.0.tgz",
          "integrity": "sha512-Yv9hDzL4aI73BEwSEh20clrY8q/uLxawaQ98lekBx6t9dQKDHcDzzV1p2YtBGTtolYtNqcWdniOnhzB+JPnQEQ==",
-         "license": "(CC-BY-4.0 AND MIT)",
          "dependencies": {
             "@fortawesome/fontawesome-common-types": "6.6.0"
          },
@@ -2165,7 +2155,6 @@
          "version": "6.6.0",
          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
          "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
-         "license": "(CC-BY-4.0 AND MIT)",
          "dependencies": {
             "@fortawesome/fontawesome-common-types": "6.6.0"
          },
@@ -2571,15 +2560,14 @@
          "license": "BSD-3-Clause"
       },
       "node_modules/@sindarius/gcodeviewer": {
-         "version": "3.7.11",
-         "resolved": "https://registry.npmjs.org/@sindarius/gcodeviewer/-/gcodeviewer-3.7.11.tgz",
-         "integrity": "sha512-8Fd0yYBguxgljhJueysIDI0Hkh7bCsBTwfWAAyMqSwwTalcf7UpfaF0lmBE5y6f4tkBjjLy+oE6oGUkLHsP0Bg==",
-         "license": "LGPL-3.0-or-later",
+         "version": "3.7.13",
+         "resolved": "https://registry.npmjs.org/@sindarius/gcodeviewer/-/gcodeviewer-3.7.13.tgz",
+         "integrity": "sha512-VADagtkvPlPmPOkFJ2qZSiQ/+SjBN/c5HLqBjsTws8pwvCrrcoXtwECl/DYNiji7W5V7g1Fy61do9Ow3g2aS0w==",
          "dependencies": {
-            "@babylonjs/core": "^7.13.1",
-            "@babylonjs/inspector": "^7.13.1",
-            "@babylonjs/loaders": "^7.13.1",
-            "@babylonjs/materials": "^7.13.1",
+            "@babylonjs/core": "^7.29.0",
+            "@babylonjs/inspector": "^7.29.0",
+            "@babylonjs/loaders": "^7.29.0",
+            "@babylonjs/materials": "^7.29.0",
             "d3": "^7.4.4"
          }
       },
@@ -2896,7 +2884,6 @@
          "version": "15.7.13",
          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
          "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-         "license": "MIT",
          "peer": true
       },
       "node_modules/@types/qs": {
@@ -2914,10 +2901,9 @@
          "license": "MIT"
       },
       "node_modules/@types/react": {
-         "version": "18.3.9",
-         "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.9.tgz",
-         "integrity": "sha512-+BpAVyTpJkNWWSSnaLBk6ePpHLOGJKnEQNbINNovPWzvEUyAe3e+/d494QdEh71RekM/qV7lw6jzf1HGrJyAtQ==",
-         "license": "MIT",
+         "version": "18.3.11",
+         "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+         "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
          "peer": true,
          "dependencies": {
             "@types/prop-types": "*",
@@ -2925,10 +2911,9 @@
          }
       },
       "node_modules/@types/react-dom": {
-         "version": "18.3.0",
-         "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-         "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-         "license": "MIT",
+         "version": "18.3.1",
+         "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+         "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
          "peer": true,
          "dependencies": {
             "@types/react": "*"
@@ -4657,10 +4642,9 @@
          }
       },
       "node_modules/babylonjs-gltf2interface": {
-         "version": "7.27.0",
-         "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.27.0.tgz",
-         "integrity": "sha512-PMoenflARm9PenwuVSTV68otMhd3Wb6fGfH5T8R9AObZtR+PSHCoduV60qiMjNi1F2cyFJbIhexnbk2U1wn79g==",
-         "license": "Apache-2.0",
+         "version": "7.29.0",
+         "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.29.0.tgz",
+         "integrity": "sha512-6WzAOKRu4G4YYZh+SgLXdVpoISYFpT2ENbrPT7VES5wTxy7tSqHbchBb3oafqCxh+/h12oQC+8J9PbvUUVI0yg==",
          "peer": true
       },
       "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "@duet3d/motionanalysis": "^3.4.0",
       "@duet3d/objectmodel": "~3.6.0-alpha.1",
       "@mdi/font": "^7.4.47",
-      "@sindarius/gcodeviewer": "^3.7.11",
+      "@sindarius/gcodeviewer": "^3.7.13",
       "chart.js": "^2.9.4",
       "chartjs-adapter-date-fns": "^1.0.0",
       "date-fns": "^2.30.0",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1027,7 +1027,8 @@
       "perimeterOnly": "Perimeter Only",
       "progressMode": "Progress Mode",
       "cancelObj": "Cancel Object",
-      "resumeObj": "Resume Object"
+      "resumeObj": "Resume Object",
+      "persistTravels": "Persist Travels"
     },
     "heightmap": {
       "menuCaption": "Height Map",

--- a/src/plugins/GCodeViewer/GCodeViewer.vue
+++ b/src/plugins/GCodeViewer/GCodeViewer.vue
@@ -226,6 +226,7 @@
 					<v-switch :disabled="!canCancelObject" :label="jobSelectionLabel" :title="$t('plugins.gcodeViewer.showObjectSelection.title')" class="mt-4" v-model="showObjectSelection"></v-switch>
 					<v-switch :label="$t('plugins.gcodeViewer.showCursor')" v-model="showCursor"></v-switch>
 					<v-switch :label="$t('plugins.gcodeViewer.showTravels')" v-model="showTravelLines"></v-switch>
+					<v-switch :label="$t('plugins.gcodeViewer.persistTravels')" v-model="persistTravels" />
 					<v-switch :label="$t('plugins.gcodeViewer.viewGCode')" v-model="viewGCode"></v-switch>
 				</v-card>
 				<v-expansion-panels>
@@ -442,6 +443,7 @@ export default {
 			testData: '',
 			showCursor: false,
 			showTravelLines: false,
+			persistTravels: false,
 			selectedFile: '',
 			nthRow: 1,
 			renderQuality: 1,
@@ -939,6 +941,7 @@ export default {
 			viewer.gcodeProcessor.perimeterOnly = this.perimeterOnly;
 			viewer.gcodeProcessor.currentWorkplace = this.currentWorkplace;
 			viewer.gcodeProcessor.progressMode = this.progressMode;
+			viewer.gcodeProcessor.persistTravels = this.persistTravels;
 			viewer.setZBelt(this.zBelt, this.zBeltAngle);
 			if(this.g1AsExtrusion){
 				this.renderQuality = 5;
@@ -1045,6 +1048,12 @@ export default {
 		},
 		'showTravelLines': (newVal) => {
 			viewer.toggleTravels(newVal);
+		},
+		'persistTravels': function(newVal) { 
+			this.showTravelLines = true
+			viewer.gcodeProcessor.setTravelPersistence(newVal);
+			viewer.gcodeProcessor.forceRedraw();
+			
 		},
 		'visualizingCurrentJob': function (newValue) {
 			if (newValue == false) {


### PR DESCRIPTION
Add persistent travel visualization option
Fix an issue with parsing multiple g-code commands in a single line
Fix an issue with the view cube not working properly when clicked. 