### PR TITLE
Ensure mm/min in CNC mode

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -737,6 +737,7 @@
       "unitMm": "mm",
       "unitInchSpeed": "ipm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Einzelbettsteuerung",
       "groupTools": "Identische Werkzeuge gruppieren",
       "singleChamberControl": "Einkammersteuerung"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -736,6 +736,7 @@
       "unitMm": "mm",
       "unitInchSpeed": "ipm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Single bed control",
       "groupTools": "Group identical tools",
       "singleChamberControl": "Single chamber control"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -737,6 +737,7 @@
       "unitMm": "mm",
       "unitInchSpeed": "ipm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Control de cama individual",
       "groupTools": "Agrupar herramientas idénticas",
       "singleChamberControl": "Control de cámara única"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -737,6 +737,7 @@
       "unitInches": "pouces",
       "unitMm": "millimètre",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Commande lit simple",
       "groupTools": "Regrouper les outils identiques",
       "singleChamberControl": "Commande à chambre unique"

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -736,6 +736,7 @@
       "unitMm": "mm",
       "unitInchSpeed": "ipm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Csoportos asztal vezérlés",
       "groupTools": "Azonos szerszámok csoportosítása",
       "singleChamberControl": "Csoportos kamra vezérlés"

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -737,6 +737,7 @@
       "unitInches": "インチ",
       "unitMm": "んん",
       "unitMmSpeed": "mm/秒",
+      "unitMmPerMinSpeed": "mm/分",
       "singleBedControl": "シングルベッドコントロール",
       "groupTools": "同一のツールをグループ化する",
       "singleChamberControl": "シングルチャンバー制御"

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -738,7 +738,8 @@
       "unitInchSpeed": "ipm",
       "unitInches": "inches",
       "unitMm": "mm",
-      "unitMmSpeed": "mm/sec"
+      "unitMmSpeed": "mm/sec",
+      "unitMmPerMinSpeed": "mm/min"
     },
     "settingsBehaviour": {
       "behaviourJobStart": "Schakel niet automatisch over naar Statuspaneel bij het starten van de taak",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -737,6 +737,7 @@
       "unitInches": "cale",
       "unitMm": "mm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Sterowanie pojedynczym łóżkiem",
       "groupTools": "Pogrupuj identyczne narzędzia",
       "singleChamberControl": "Sterowanie jednokomorowe"

--- a/src/i18n/pt_br.json
+++ b/src/i18n/pt_br.json
@@ -737,6 +737,7 @@
       "unitInches": "polegadas",
       "unitMm": "milímetros",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "Controle de cama de solteiro",
       "groupTools": "Agrupar ferramentas idênticas",
       "singleChamberControl": "Controle de câmara única"

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -737,6 +737,7 @@
       "unitInches": "дюймы",
       "unitMm": "мм",
       "unitMmSpeed": "мм/с",
+      "unitMmPerMinSpeed": "мм/мин",
       "singleBedControl": "Раздельное управление столами",
       "groupTools": "Сгруппировать одинаковые инструменты",
       "singleChamberControl": "Раздельное управление термокамерами"

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -737,6 +737,7 @@
       "unitInches": "inç",
       "unitMm": "mm",
       "unitMmSpeed": "mm/sn",
+      "unitMmPerMinSpeed": "mm/dk",
       "singleBedControl": "Tek kişilik yatak kontrolü",
       "groupTools": "Grup özdeş araçlar",
       "singleChamberControl": "Tek bölmeli kontrol"

--- a/src/i18n/uk.json
+++ b/src/i18n/uk.json
@@ -736,6 +736,7 @@
       "unitMm": "mm",
       "unitInchSpeed": "ipm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/хв",
       "singleBedControl": "Контроль столом",
       "groupTools": "Група ідентичних інструментів",
       "singleChamberControl": "Контроль термокамерою"

--- a/src/i18n/zh_cn.json
+++ b/src/i18n/zh_cn.json
@@ -736,6 +736,7 @@
       "unitMm": "mm",
       "unitInchSpeed": "ipm",
       "unitMmSpeed": "mm/s",
+      "unitMmPerMinSpeed": "mm/min",
       "singleBedControl": "单个热床控制",
       "groupTools": "分组相同的工具",
       "singleChamberControl": "单个加热室控制"

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -105,11 +105,16 @@ export function displaySize(bytes: number | null | undefined) {
 /**
  * Display a move speed
  * @param speed Speed in mm/s
- * @returns Formatted move speed in mm/s or ipm
+ * @returns Formatted move speed in mm/s (or: mm/min in CNC-Mode) or ipm
  */
 export function displayMoveSpeed(speed: number | null | undefined) {
-	if (typeof speed === "number" && store.state.settings.displayUnits === UnitOfMeasure.imperial) {
-		return display(speed * 60 / 25.4, 1, i18n.t("panel.settingsAppearance.unitInchSpeed"));
+	if (typeof speed === "number") {
+		if (store.state.settings.displayUnits === UnitOfMeasure.imperial) {
+			return display(speed * 60 / 25.4, 1, i18n.t("panel.settingsAppearance.unitInchSpeed"));
+		}
+		if (store.state.machine.model.state.machineMode === MachineMode.cnc) {
+			return display(speed * 60, 1, i18n.t("panel.settingsAppearance.unitMmPerMinSpeed"));
+		}
 	}
 	return display(speed, 1, i18n.t("panel.settingsAppearance.unitMmSpeed"));
 }


### PR DESCRIPTION
In CNC World, feeds are ipm or mm/min. This is for historical reasons. mm/s is used nowhere that I'm aware of. Let's don't make people's lives miserable.

