### PR TITLE
fix: re-appear message dialogues after connection is re-established

### DIFF
--- a/src/components/dialogs/MessageBoxDialog.vue
+++ b/src/components/dialogs/MessageBoxDialog.vue
@@ -209,6 +209,8 @@ export default Vue.extend({
 		isReconnecting(to: boolean) {
 			if (to) {
 				this.shown = false;
+			} else if (this.currentMessageBox && this.currentMessageBox.mode !== null) {
+				this.shown = true;
 			}
 		},
 		currentMessageBox: {


### PR DESCRIPTION
Scenario: I grab my mobile and want to confirm a message dialogue after a set operation (tool change, or jogging). But the screen lock was triggered and thus the site went into background, disconnecting from the backend.



# Expected



1. I unblock my mobile
2. I wait for the connection to be re-established
3. I continue with confirming the dialogue (e.g. "Have you changed the tool for an offset check?")



# Actual (before this patch)



1. I unblock my mobile
2. I wait for the connection to be re-established
3. No message box on the screen: I have to refresh the page
4. I wait for the page to refresh; message box appears again
5. I continue with confirming the dialogue (e.g. "Have you changed the tool for an offset check?")
