### PR TITLE
Add editor option to replace tabs with spaces on save

### DIFF
--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -394,7 +394,11 @@ async function save(): Promise<boolean> {
 	saving.value = true;
 	transferProgress.value = null;
 	try {
-		if (settingsStore.editor.replaceTabsOnSave) {
+		// Job files in the G-codes directory are excluded from tab replacement: they are
+		// sliced output, so rewriting them is never intended and they can be huge
+		if (settingsStore.editor.replaceTabsOnSave &&
+			!Path.startsWith(props.filename, machineStore.model.directories.gCodes)
+		) {
 			replaceTabs();
 		}
 		const content = useMonaco.value ? editor!.getValue() : textContent.value;

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -394,11 +394,7 @@ async function save(): Promise<boolean> {
 	saving.value = true;
 	transferProgress.value = null;
 	try {
-		// Job files in the G-codes directory are excluded from tab replacement: they are
-		// sliced output, so rewriting them is never intended and they can be huge
-		if (settingsStore.editor.replaceTabsOnSave &&
-			!Path.startsWith(props.filename, machineStore.model.directories.gCodes)
-		) {
+		if (settingsStore.editor.replaceTabsOnSave) {
 			replaceTabs();
 		}
 		const content = useMonaco.value ? editor!.getValue() : textContent.value;
@@ -540,7 +536,9 @@ function indentComments() {
 // Replaces every tab character in the buffer with spaces, invoked from save() when the
 // corresponding setting is enabled. Rewrites the buffer (not just the uploaded content) so the
 // editor keeps matching the file on disk; goes through executeEdits so the change is undoable
-// and doesn't reset the cursor/scroll position
+// and doesn't reset the cursor/scroll position.
+// Files past BIG_FILE_THRESHOLD are skipped, matching the other whole-buffer operations: that
+// size means sliced job output rather than a hand-edited file, and rewriting it is expensive
 function replaceTabs() {
 	// Guard against a cleared/invalid number field in the settings; fall back to the default of 4
 	const size = settingsStore.editor.replaceTabsSize;
@@ -551,14 +549,14 @@ function replaceTabs() {
 			return;
 		}
 		const value = editor.getValue();
-		if (value.includes("\t")) {
+		if (value.length <= BIG_FILE_THRESHOLD && value.includes("\t")) {
 			const model = editor.getModel();
 			if (model) {
 				editor.executeEdits(null, [{ range: model.getFullModelRange(), text: value.replaceAll("\t", spaces) }]);
 				editor.pushUndoStop();
 			}
 		}
-	} else if (textContent.value.includes("\t")) {
+	} else if (textContent.value.length <= BIG_FILE_THRESHOLD && textContent.value.includes("\t")) {
 		// No need for the suppressDirty dance here: save() resets dirty once the upload succeeds,
 		// and on failure the buffer genuinely differs from the file so staying dirty is correct
 		textContent.value = textContent.value.replaceAll("\t", spaces);

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -394,6 +394,9 @@ async function save(): Promise<boolean> {
 	saving.value = true;
 	transferProgress.value = null;
 	try {
+		if (settingsStore.editor.replaceTabsOnSave) {
+			replaceTabs();
+		}
 		const content = useMonaco.value ? editor!.getValue() : textContent.value;
 		await machineStore.upload(
 			{ filename: props.filename, content: new Blob([content]) },
@@ -527,6 +530,34 @@ function indentComments() {
 		}
 	} else {
 		textContent.value = indent(textContent.value);
+	}
+}
+
+// Replaces every tab character in the buffer with spaces, invoked from save() when the
+// corresponding setting is enabled. Rewrites the buffer (not just the uploaded content) so the
+// editor keeps matching the file on disk; goes through executeEdits so the change is undoable
+// and doesn't reset the cursor/scroll position
+function replaceTabs() {
+	// Guard against a cleared/invalid number field in the settings; fall back to the default of 4
+	const size = settingsStore.editor.replaceTabsSize;
+	const spaces = " ".repeat((Number.isFinite(size) && size >= 1) ? Math.floor(size) : 4);
+
+	if (useMonaco.value) {
+		if (!editor) {
+			return;
+		}
+		const value = editor.getValue();
+		if (value.includes("\t")) {
+			const model = editor.getModel();
+			if (model) {
+				editor.executeEdits(null, [{ range: model.getFullModelRange(), text: value.replaceAll("\t", spaces) }]);
+				editor.pushUndoStop();
+			}
+		}
+	} else if (textContent.value.includes("\t")) {
+		// No need for the suppressDirty dance here: save() resets dirty once the upload succeeds,
+		// and on failure the buffer genuinely differs from the file so staying dirty is correct
+		textContent.value = textContent.value.replaceAll("\t", spaces);
 	}
 }
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1180,7 +1180,11 @@
 			"formatOnType": "Während der Eingabe formatieren",
 			"formatOnTypeHint": "Code während der Eingabe automatisch neu formatieren",
 			"largeFileOptimizations": "Große Dateien optimieren",
-			"largeFileOptimizationsHint": "Syntaxhervorhebung, Faltung und Klammerpaar-Hervorhebung über ~20 MB deaktivieren, um Speicher zu sparen; ausgeschaltet lassen, damit große G-Code-Dateien farbig bleiben"
+			"largeFileOptimizationsHint": "Syntaxhervorhebung, Faltung und Klammerpaar-Hervorhebung über ~20 MB deaktivieren, um Speicher zu sparen; ausgeschaltet lassen, damit große G-Code-Dateien farbig bleiben",
+			"replaceTabsOnSave": "Tabs beim Speichern durch Leerzeichen ersetzen",
+			"replaceTabsOnSaveHint": "Beim Speichern jedes Tabulatorzeichen in der Datei durch Leerzeichen ersetzen",
+			"replaceTabsSize": "Leerzeichen pro Tab",
+			"replaceTabsSizeHint": "Anzahl der Leerzeichen, durch die jeder Tab beim Speichern ersetzt wird"
 		},
 		"about": {
 			"dwc": "Duet Web Control",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1182,7 +1182,7 @@
 			"largeFileOptimizations": "Große Dateien optimieren",
 			"largeFileOptimizationsHint": "Syntaxhervorhebung, Faltung und Klammerpaar-Hervorhebung über ~20 MB deaktivieren, um Speicher zu sparen; ausgeschaltet lassen, damit große G-Code-Dateien farbig bleiben",
 			"replaceTabsOnSave": "Tabs beim Speichern durch Leerzeichen ersetzen",
-			"replaceTabsOnSaveHint": "Beim Speichern jedes Tabulatorzeichen in der Datei durch Leerzeichen ersetzen. Gilt nicht für Druckdateien im G-Code-Verzeichnis.",
+			"replaceTabsOnSaveHint": "Beim Speichern jedes Tabulatorzeichen in der Datei durch Leerzeichen ersetzen. Wird bei sehr großen Dateien übersprungen.",
 			"replaceTabsSize": "Leerzeichen pro Tab",
 			"replaceTabsSizeHint": "Anzahl der Leerzeichen, durch die jeder Tab beim Speichern ersetzt wird"
 		},

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1182,7 +1182,7 @@
 			"largeFileOptimizations": "Große Dateien optimieren",
 			"largeFileOptimizationsHint": "Syntaxhervorhebung, Faltung und Klammerpaar-Hervorhebung über ~20 MB deaktivieren, um Speicher zu sparen; ausgeschaltet lassen, damit große G-Code-Dateien farbig bleiben",
 			"replaceTabsOnSave": "Tabs beim Speichern durch Leerzeichen ersetzen",
-			"replaceTabsOnSaveHint": "Beim Speichern jedes Tabulatorzeichen in der Datei durch Leerzeichen ersetzen",
+			"replaceTabsOnSaveHint": "Beim Speichern jedes Tabulatorzeichen in der Datei durch Leerzeichen ersetzen. Gilt nicht für Druckdateien im G-Code-Verzeichnis.",
 			"replaceTabsSize": "Leerzeichen pro Tab",
 			"replaceTabsSizeHint": "Anzahl der Leerzeichen, durch die jeder Tab beim Speichern ersetzt wird"
 		},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1182,7 +1182,11 @@
 			"formatOnType": "Format on type",
 			"formatOnTypeHint": "Automatically reformat code as it is being typed",
 			"largeFileOptimizations": "Optimize large files",
-			"largeFileOptimizationsHint": "Drop syntax highlighting, folding and bracket matching above ~20 MB to save memory; leave off to keep big G-code files coloured"
+			"largeFileOptimizationsHint": "Drop syntax highlighting, folding and bracket matching above ~20 MB to save memory; leave off to keep big G-code files coloured",
+			"replaceTabsOnSave": "Replace tabs with spaces on save",
+			"replaceTabsOnSaveHint": "Convert every tab character in the file to spaces whenever it is saved",
+			"replaceTabsSize": "Spaces per tab",
+			"replaceTabsSizeHint": "Number of spaces each tab is replaced by when saving"
 		},
 		"about": {
 			"dwc": "Duet Web Control",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1184,7 +1184,7 @@
 			"largeFileOptimizations": "Optimize large files",
 			"largeFileOptimizationsHint": "Drop syntax highlighting, folding and bracket matching above ~20 MB to save memory; leave off to keep big G-code files coloured",
 			"replaceTabsOnSave": "Replace tabs with spaces on save",
-			"replaceTabsOnSaveHint": "Convert every tab character in the file to spaces whenever it is saved",
+			"replaceTabsOnSaveHint": "Convert every tab character in the file to spaces whenever it is saved. Does not apply to job files in the G-codes directory.",
 			"replaceTabsSize": "Spaces per tab",
 			"replaceTabsSizeHint": "Number of spaces each tab is replaced by when saving"
 		},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1184,7 +1184,7 @@
 			"largeFileOptimizations": "Optimize large files",
 			"largeFileOptimizationsHint": "Drop syntax highlighting, folding and bracket matching above ~20 MB to save memory; leave off to keep big G-code files coloured",
 			"replaceTabsOnSave": "Replace tabs with spaces on save",
-			"replaceTabsOnSaveHint": "Convert every tab character in the file to spaces whenever it is saved. Does not apply to job files in the G-codes directory.",
+			"replaceTabsOnSaveHint": "Convert every tab character in the file to spaces whenever it is saved. Skipped for very large files.",
 			"replaceTabsSize": "Spaces per tab",
 			"replaceTabsSizeHint": "Number of spaces each tab is replaced by when saving"
 		},

--- a/src/pages/Settings/[[tab]].vue
+++ b/src/pages/Settings/[[tab]].vue
@@ -512,6 +512,16 @@
 												  :label="$t('settings.editor.bracketPairColorization')"
 												  v-hint="$t('settings.editor.bracketPairColorizationHint')"
 												  density="comfortable" hide-details />
+										<v-switch v-model="settingsStore.editor.replaceTabsOnSave" color="primary"
+												  :label="$t('settings.editor.replaceTabsOnSave')"
+												  v-hint="$t('settings.editor.replaceTabsOnSaveHint')"
+												  density="comfortable" hide-details />
+										<v-text-field v-model.number="settingsStore.editor.replaceTabsSize" type="number"
+													  :disabled="!settingsStore.editor.replaceTabsOnSave"
+													  :label="$t('settings.editor.replaceTabsSize')"
+													  v-hint="$t('settings.editor.replaceTabsSizeHint')"
+													  variant="outlined" density="comfortable" hide-details
+													  min="1" max="16" class="mt-2" />
 									</v-card-text>
 								</v-card>
 							</v-col>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -457,6 +457,10 @@ export const useSettingsStore = defineStore("settings", {
 			/** Monaco's large-file optimisations: above ~20 MB it drops syntax highlighting, folding and
 			 * bracket matching to save memory. Off by default so big job gcode files still colour */
 			largeFileOptimizations: false,
+			/** Replace every tab character in the buffer with spaces when the file is saved */
+			replaceTabsOnSave: false,
+			/** Number of spaces each tab is replaced by when {@link replaceTabsOnSave} is enabled */
+			replaceTabsSize: 4,
 		},
 
 		/**

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -457,7 +457,8 @@ export const useSettingsStore = defineStore("settings", {
 			/** Monaco's large-file optimisations: above ~20 MB it drops syntax highlighting, folding and
 			 * bracket matching to save memory. Off by default so big job gcode files still colour */
 			largeFileOptimizations: false,
-			/** Replace every tab character in the buffer with spaces when the file is saved */
+			/** Replace every tab character in the buffer with spaces when the file is saved.
+			 * Job files in the G-codes directory are exempt (sliced output, potentially huge) */
 			replaceTabsOnSave: false,
 			/** Number of spaces each tab is replaced by when {@link replaceTabsOnSave} is enabled */
 			replaceTabsSize: 4,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -458,7 +458,8 @@ export const useSettingsStore = defineStore("settings", {
 			 * bracket matching to save memory. Off by default so big job gcode files still colour */
 			largeFileOptimizations: false,
 			/** Replace every tab character in the buffer with spaces when the file is saved.
-			 * Job files in the G-codes directory are exempt (sliced output, potentially huge) */
+			 * Files past the editor's big-file threshold are exempt, like the other
+			 * whole-buffer operations (they are sliced job output, not hand-edited files) */
 			replaceTabsOnSave: false,
 			/** Number of spaces each tab is replaced by when {@link replaceTabsOnSave} is enabled */
 			replaceTabsSize: 4,


### PR DESCRIPTION
## Summary

Adds a new option on the **Settings > Editor** tab that, when enabled, replaces every tab character in a file with spaces whenever the file is saved. The number of spaces per tab is configurable (default 4, range 1-16); the field is disabled while the feature is off. The feature is off by default so existing behaviour is unchanged.

The conversion is skipped for files past the editor's existing big-file threshold (`BIG_FILE_THRESHOLD`, 32 MiB) - the same mechanism that already disables Revert for large files. Files that size are sliced job output rather than hand-edited files, and a whole-buffer rewrite at that size is expensive.

## Implementation notes

- Two new persisted keys under `editor` in the settings store: `replaceTabsOnSave` (default `false`) and `replaceTabsSize` (default `4`). Existing saved settings pick up the defaults through the usual merge-on-load path.
- `save()` in `MonacoEditor.vue` converts tabs before uploading. The conversion rewrites the editor buffer itself (via `executeEdits`) rather than just the uploaded bytes, so the on-screen content always matches the file on disk, the edit is undoable, and cursor/scroll position are preserved. The plain-textarea fallback is handled as well.
- The space count is validated at the point of use; an invalid or cleared value falls back to 4.
- English and German translations included; other locales fall back to English.

## Testing

- `vue-tsc --noEmit` passes.
- Manual: enable the switch, open a file containing tabs, save, and confirm tabs become spaces both in the editor buffer and in the saved file; with the switch off, tabs are preserved. Saving a file above the big-file threshold must leave its tabs untouched even with the switch on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)