### PR TITLE
Add "Copy Path" entry to the file list context menu

### DIFF
--- a/src/components/lists/FileList.vue
+++ b/src/components/lists/FileList.vue
@@ -401,6 +401,12 @@
 				</template>
 				<v-list-item-title>{{ $t("list.fileList.open") }}</v-list-item-title>
 			</v-list-item>
+			<v-list-item v-if="contextMenu.target" @click="copyPathFromContext">
+				<template #prepend>
+					<v-icon>mdi-content-copy</v-icon>
+				</template>
+				<v-list-item-title>{{ $t("list.fileList.copyPath") }}</v-list-item-title>
+			</v-list-item>
 			<v-list-item v-if="!noDownload && selectedEntries.length > 0" @click="startDownload">
 				<template #prepend>
 					<v-icon>mdi-cloud-download</v-icon>
@@ -480,6 +486,7 @@ import { useComponentSettings } from "@/composables/useComponentSettings";
 import i18n from "@/i18n";
 import { useMachineStore } from "@/stores/machine";
 import { ContextMenuType, FileTransferType, LogLevel, useUiStore } from "@/stores/ui";
+import { copyToClipboard } from "@/utils/clipboard";
 import { displaySize } from "@/utils/display";
 import { saveBlob } from "@/utils/download";
 import { getErrorMessage } from "@/utils/errors";
@@ -1509,6 +1516,23 @@ function runMacroFromContext() {
 		return;
 	}
 	emit("fileRunMacro", target, browser.directory.value);
+}
+
+// Copy the item's full path (e.g. "0:/sys/config.g") for pasting into M98/M32 calls and the like.
+// Clipboard writes have no visible effect of their own, so confirm with a notification
+async function copyPathFromContext() {
+	contextMenu.shown = false;
+	const target = contextMenu.target;
+	if (!target) {
+		return;
+	}
+	const path = Path.combine(browser.directory.value, target.name);
+	try {
+		await copyToClipboard(path);
+		uiStore.makeNotification(LogLevel.info, i18n.global.t("list.fileList.pathCopied"), path);
+	} catch (e) {
+		uiStore.notifyError(e, i18n.global.t("list.fileList.copyPath"));
+	}
 }
 
 // Run Macro is offered inside the system tree on files whose name ends in a runnable

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -598,6 +598,8 @@
 			"edit": "Bearbeiten",
 			"fileInfo": "Dateiinfo",
 			"runMacro": "Makro ausführen",
+			"copyPath": "Pfad kopieren",
+			"pathCopied": "Pfad in die Zwischenablage kopiert",
 			"download": "Herunterladen",
 			"downloadZIP": "Als ZIP herunterladen",
 			"loading": "Dateien werden geladen...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -596,6 +596,8 @@
 			"edit": "Edit",
 			"fileInfo": "File Info",
 			"runMacro": "Run Macro",
+			"copyPath": "Copy Path",
+			"pathCopied": "Path copied to clipboard",
 			"download": "Download",
 			"downloadZIP": "Download as ZIP",
 			"loading": "Loading files...",


### PR DESCRIPTION
## Summary

Adds a **Copy Path** entry to the file list's right-click context menu that copies the item's full machine path (e.g. `0:/sys/config.g`) to the clipboard, ready to paste into `M98`/`M32` calls, `daemon.g`, or other macros. The entry is shown for both files and directories.

## Implementation notes

- The path is built with `Path.combine(directory, name)`, so it always carries the volume prefix.
- Uses the existing `copyToClipboard` utility, which falls back to a hidden textarea + `execCommand` on plain-HTTP origins where the async Clipboard API is unavailable - the common case when DWC is served directly from the printer.
- Since a clipboard write has no visible effect of its own, a successful copy is confirmed with an info notification showing the copied path; failures surface through the standard error notification.
- English and German translations included; other locales fall back to English.

## Testing

- `vue-tsc --noEmit` passes.
- Manual: right-click a file or directory in any file list (System, Macros, Jobs, ...), choose Copy Path, and paste - the full path including the volume prefix is on the clipboard and a confirmation notification is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)