### PR TITLE
Fix "Install Update" silently failing to pick a file on Windows/Chrome

### DIFF
--- a/src/composables/useFirmwareInstall.ts
+++ b/src/composables/useFirmwareInstall.ts
@@ -103,9 +103,17 @@ export function useFirmwareInstall() {
 	}
 
 	function matchesBoardBinary(boardValue: string, fileName: string): boolean {
-		const binRegEx = new RegExp(boardValue.replace(/\.bin$/, "(.*)\\.bin"), "i");
-		const uf2RegEx = new RegExp(boardValue.replace(/\.uf2$/, "(.*)\\.uf2"), "i");
-		return binRegEx.test(fileName) || uf2RegEx.test(fileName);
+		try {
+			const binRegEx = new RegExp(boardValue.replace(/\.bin$/, "(.*)\\.bin"), "i");
+			const uf2RegEx = new RegExp(boardValue.replace(/\.uf2$/, "(.*)\\.uf2"), "i");
+			return binRegEx.test(fileName) || uf2RegEx.test(fileName);
+		} catch {
+			// boardValue comes straight from the object model's board.firmwareFileName - if it ever
+			// contains characters that don't form a valid pattern (e.g. an unmatched bracket),
+			// new RegExp() throws a SyntaxError that would otherwise abort classify() for every
+			// other picked file too. Treat an unparsable board name as simply "doesn't match"
+			return false;
+		}
 	}
 
 	// Match a firmware binary against every board, not just the first hit: identical boards (e.g.

--- a/src/composables/useFirmwareInstallController.ts
+++ b/src/composables/useFirmwareInstallController.ts
@@ -85,13 +85,17 @@ export function useFirmwareInstallController(): FirmwareInstallController {
 				Events.emit("installPlugin", { zipFilename: e.file.name, zipBlob: e.file, zipFile: e.archive, start: true });
 				return;
 			}
-			if (!(e instanceof OperationCancelledError)) {
-				console.warn(e);
+			if (e instanceof OperationCancelledError) {
+				return;
 			}
-			// SBC package installs are dispatched from the classifier and report their own failures
-			if (e instanceof ZipExtractionError) {
-				uiStore.notifyError(e, i18n.global.t("notification.decompress.errorTitle"));
-			}
+			console.warn(e);
+			// SBC package installs are dispatched from the classifier and report their own failures.
+			// Anything else planFiles() can throw (a malformed zip, an unexpected error while
+			// classifying a file, ...) must still reach the user - silently swallowing it here made
+			// picking a file look like a complete no-op, with nothing to explain why
+			uiStore.notifyError(e, e instanceof ZipExtractionError
+				? i18n.global.t("notification.decompress.errorTitle")
+				: i18n.global.t("notification.firmwareInstall.planFailedTitle"));
 			return;
 		}
 
@@ -112,6 +116,19 @@ export function useFirmwareInstallController(): FirmwareInstallController {
 			// Auto-reload DWC after a www-only refresh of the same host
 			if (plan.webInterfaceTouched && machineStore.connector?.hostname === location.host) {
 				location.reload();
+				return;
+			}
+
+			// Nothing recognisable came out of this pick: classify() always finds SOME destination
+			// for a non-.deb file, so it landed on the SD card, but none of the branches above fired -
+			// it didn't match any connected board's firmwareFileName, a WiFi/display module, or a
+			// config file, so no M997 was queued and no reset prompt showed. Without this the whole
+			// pick looks like a no-op (a brief upload toast and then nothing) - most commonly because
+			// the picked file's name doesn't match what the connected board reports as its own
+			// firmwareFileName
+			if (plan.files.length > 0 && !plan.configReplaced && !plan.webInterfaceTouched) {
+				uiStore.log(LogLevel.warning, i18n.global.t("notification.firmwareInstall.notRecognisedTitle"),
+					i18n.global.t("notification.firmwareInstall.notRecognisedMessage"));
 			}
 		} catch (e) {
 			// upload() notifies about every file it failed to transfer, so no extra message here

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -325,6 +325,11 @@
 			"standaloneUpdateInSbcModeError": "Sie versuchen ein DWC-Paket für den Standalone-Modus hochzuladen, obwohl die Maschine im SBC-Modus läuft. Dies wird nicht unterstützt. Bitte benutzen Sie apt update/upgrade, um ihr System zu aktualisieren.",
 			"sbcUpdateInStandaloneError": "Sie versuchen ein DWC-Paket für den SBC-Modus hochzuladen, obwohl die Maschine im Standalone-Modus läuft. Dies wird nicht unterstützt. Bitte verwenden Sie stattdessen das Paket DuetWebControl-SD.zip."
 		},
+		"firmwareInstall": {
+			"planFailedTitle": "Verarbeitung der ausgewählten Datei(en) fehlgeschlagen",
+			"notRecognisedTitle": "Firmware nicht erkannt",
+			"notRecognisedMessage": "Die Datei wurde hochgeladen, aber sie passte zu keinem verbundenen Board, Modul oder keiner Konfigurationsdatei, daher wurde nichts installiert. Bitte überprüfen Sie, ob der Dateiname zu Ihrem Board passt."
+		},
 		"delete": {
 			"errorTitle": "Konnte {0} nicht löschen",
 			"errorMessageDirectory": "Bitte stellen Sie sicher, dass das ausgewählte Verzeichnis leer ist",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -325,6 +325,11 @@
 			"standaloneUpdateInSbcModeError": "You are trying to upload a standalone DWC bundle in SBC mode. This is NOT supported. Please use apt update/upgrade to update your system.",
 			"sbcUpdateInStandaloneError": "You are trying to upload an SBC DWC bundle in standalone mode. This is NOT supported. Please use the DuetWebControl-SD.zip package instead."
 		},
+		"firmwareInstall": {
+			"planFailedTitle": "Failed to process the selected file(s)",
+			"notRecognisedTitle": "Firmware not recognised",
+			"notRecognisedMessage": "The file was uploaded, but it did not match any connected board, module, or configuration file, so nothing was installed. Please check the filename matches what your board expects."
+		},
 		"delete": {
 			"errorTitle": "Failed to delete {0}",
 			"errorMessageDirectory": "Please make sure that this directory is empty",

--- a/src/pages/Settings/[[tab]].vue
+++ b/src/pages/Settings/[[tab]].vue
@@ -907,9 +907,6 @@
 		</v-card>
 		</div>
 
-		<input ref="firmwareInput" type="file" multiple :accept="firmwareAccept" hidden
-			   @change="onFirmwarePicked" />
-
 		<FirmwareUpdateDialog v-model:shown="firmwareDialog.shown" :plan="firmwareDialog.plan"
 							  @confirmed="firmwareController.onFirmwareUpdateConfirmed"
 							  @cancelled="firmwareController.onFirmwareUpdateCancelled" />
@@ -1359,7 +1356,6 @@ const cacheSaveDelayMs = computed({
 // #region Firmware install
 const firmwareController = useFirmwareInstallController();
 const { firmwareDialog, configUpdatedDialog } = firmwareController;
-const firmwareInput = ref<HTMLInputElement | null>(null);
 const installingFirmware = ref(false);
 
 // .deb is only usable in SBC mode (installSystemPackage); .crt/.key are HTTPS certs
@@ -1367,17 +1363,32 @@ const firmwareAccept = computed(() => machineStore.model.sbc !== null
 	? ".zip,.bin,.uf2,.deb,.crt,.key"
 	: ".zip,.bin,.uf2,.crt,.key");
 
+// A single persistent, reused hidden <input type="file"> was found (via extensive live testing
+// against a real board on Windows/Chrome) to intermittently stop handing back a selection at all -
+// the browser opens the native picker, the user picks a file, and `change` fires with an empty
+// FileList, even though a freshly-created element with byte-for-byte identical attributes picked
+// up the same file correctly every time. Creating a fresh, single-use input on every click and
+// discarding it afterwards sidesteps whatever internal state the long-lived element was getting
+// stuck in - confirmed as the fix by the same live testing
 function pickFirmwareFiles() {
 	if (installingFirmware.value) {
 		return;
 	}
-	firmwareInput.value?.click();
+	const input = document.createElement("input");
+	input.type = "file";
+	input.multiple = true;
+	input.accept = firmwareAccept.value;
+	input.hidden = true;
+	document.body.appendChild(input);
+	input.addEventListener("change", () => {
+		const files = input.files;
+		input.remove();
+		onFirmwarePicked(files);
+	}, { once: true });
+	input.click();
 }
 
-async function onFirmwarePicked(event: Event) {
-	const target = event.target as HTMLInputElement;
-	const files = target.files;
-	target.value = "";
+async function onFirmwarePicked(files: FileList | null) {
 	if (!files || files.length === 0) {
 		return;
 	}


### PR DESCRIPTION
## Summary

The Settings > Infrastructure **Install Update** button reused a single, persistent hidden `<input type="file">` element across every click. On Windows/Chrome this specific long-lived element could stop handing back a file selection entirely: the native picker opens, the user picks a file, `change` fires, but `input.files` comes back empty - with no error anywhere in the app, since nothing downstream of an empty `FileList` had any reason to complain. The button appeared to do nothing at all after the file dialog closed.

## Root cause and how it was isolated

This was tracked down through live testing against a real board (Windows/Chrome):
- Removing the `accept` attribute entirely made no difference.
- Triggering the raw DOM `.click()` directly (bypassing the Vuetify button) made no difference.
- A **freshly-created** `<input type="file">` element, with attributes byte-for-byte identical to the persistent one (`type`, `multiple`, `accept`, `hidden`), picked up the same file correctly on the first try - every time, on both the Settings and Explorer pages.

That isolates the fault to the one specific, long-lived DOM node itself, independent of its attributes, how it's triggered, or the page it's on. The fix: `pickFirmwareFiles()` now creates a single-use `<input>` on every click and discards it afterwards, instead of reusing one persistent element - matching the pattern proven reliable by testing. The static `<input>` was removed from the template.

## Additional hardening found along the way

Two related silent-failure paths surfaced while chasing this down and are fixed here too, independent of the root cause above:

- `matchesBoardBinary()` built a `RegExp` directly from a board-reported `firmwareFileName`. A name containing characters that don't form a valid pattern would throw and silently abort classification for **every other picked file**, not just the one board. Now caught and treated as "no match" for that board.
- Any exception from `planFiles()` other than the two already-handled types (`PluginBundleDetectedError`, `ZipExtractionError`) was swallowed by a bare `console.warn` with zero UI feedback. Now surfaces a proper error notification.
- Added a notification for the case where a file uploads successfully but doesn't match any connected board/module/config file - previously this silently uploaded the file and did nothing further, with no indication that nothing was actually installed.

## Testing

- `vue-tsc --noEmit` and `npm run build` both pass.
- Verified against a real Duet board in standalone mode (Windows/Chrome): confirmed the original bug, isolated it via extensive live DevTools testing (see above), and confirmed Install Update now works correctly with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)